### PR TITLE
Improve reported disk archive usage

### DIFF
--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -95,7 +95,7 @@ module.exports = class ArchivesAPI {
 
     // add to the swarm
     this.archiver.loadArchive(key).then(() => {
-      this.archiver._swarm(key, {upload: true, download: true})
+      this.archiver._swarmArchive(key, {upload: true, download: true})
     })
 
     // respond

--- a/lib/apis/pages.js
+++ b/lib/apis/pages.js
@@ -38,9 +38,10 @@ class PagesAPI {
         record.manifest = await this.cloud.archiver.getManifest(archive.key)
         record.title = record.manifest ? record.manifest.title : false
         record.numPeers = archive.numPeers
-        record.diskUsage = archive.diskUsage
+        record.diskUsage = await this.cloud.archiver.getArchiveDiskUsage(archive.key)
         return record
       }))
+      console.log(userArchives)
     }
 
     res.render('frontpage', {

--- a/lib/apis/pages.js
+++ b/lib/apis/pages.js
@@ -41,7 +41,6 @@ class PagesAPI {
         record.diskUsage = await this.cloud.archiver.getArchiveDiskUsage(archive.key)
         return record
       }))
-      console.log(userArchives)
     }
 
     res.render('frontpage', {

--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -46,10 +46,24 @@ module.exports = class Archiver {
   async getArchiveDiskUsage (key, {forceUpdate} = {}) {
     key = datEncoding.toStr(key)
     var archive = this.getArchive(key)
-    if (!archive) return
+    if (!archive) return 0
     if (forceUpdate || !archive.diskUsage) {
+      // read size on disk
+      let oldUsage = archive.diskUsage || 0
       let path = this._getArchiveFilesPath(key)
       archive.diskUsage = await getFolderSize(path)
+
+      // if different, update the user record as well
+      if (oldUsage != archive.diskUsage) {
+        let diff = archive.diskUsage - oldUsage
+        this.cloud.archivesDB.getByKey(key).then(archiveRecord => {
+          archiveRecord.hostingUsers.forEach(async id => {
+            let userRecord = await this.cloud.usersDB.getByID(id)
+            userRecord.diskUsage += diff
+            this.cloud.usersDB.update(id, {diskUsage: userRecord.diskUsage})
+          })
+        })
+      }
     }
     return archive.diskUsage
   }

--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -1,6 +1,8 @@
+const crypto = require('crypto')
 const path = require('path')
 const promisify = require('es6-promisify')
 const hyperdrive = require('hyperdrive')
+const hypercoreProtocol = require('hypercore-protocol')
 const datEncoding = require('dat-encoding')
 const discoverySwarm = require('discovery-swarm')
 const swarmDefaults = require('datland-swarm-defaults')
@@ -8,6 +10,7 @@ const ms = require('ms')
 const pda = require('pauls-dat-api')
 const throttle = require('lodash.throttle')
 const lock = require('./lock')
+const {DAT_SWARM_PORT} = require('./const')
 const debug = require('debug')('archiver')
 const debugJobs = require('debug')('jobs')
 
@@ -23,7 +26,14 @@ module.exports = class Archiver {
     this.cloud = cloud
     this.config = cloud.config
     this.archives = {}
+    this.archivesByDKey = {}
     this.loadPromises = {}
+    this.swarm = null
+    this.networkId = crypto.randomBytes(32)
+    this._connIdCounter = 0 // for debugging
+
+    // initiate the swarm
+    this._initializeSwarm()
 
     // periodically construct the indexes
     this.indexes = {popular: []}
@@ -93,7 +103,10 @@ module.exports = class Archiver {
     p.then(clear, clear)
 
     // when done, save the archive instance
-    p.then(archive => { this.archives[key] = archive })
+    p.then(archive => {
+      this.archives[key] = archive
+      this.archivesByDKey[datEncoding.toStr(archive.discoveryKey)] = archive
+    })
 
     return p
   }
@@ -102,9 +115,10 @@ module.exports = class Archiver {
     key = datEncoding.toStr(key)
     var archive = this.archives[key]
     if (archive) {
-      this._swarm(archive, {download: false, upload: false})
+      this._swarmArchive(archive, {download: false, upload: false})
       await new Promise(resolve => archive.close(resolve))
       delete this.archives[key]
+      delete this.archivesByDKey[datEncoding.toStr(archive.discoveryKey)]
     } else {
       // is archive still loading?
       // wait to finish then try to close
@@ -181,7 +195,7 @@ module.exports = class Archiver {
     // reconfigure swarms based on quota overages
     var quotaPct = this.config.getUserDiskQuotaPct(userRecord)
     userRecord.archives.forEach(archiveRecord => {
-      this._swarm(archiveRecord.key, {
+      this._swarmArchive(archiveRecord.key, {
         upload: true, // always upload
         download: quotaPct < 1 // only download if the user has capacity
       })
@@ -240,6 +254,7 @@ module.exports = class Archiver {
   async _loadArchiveInner (archivePath, key) {
     // create the archive instance
     var archive = hyperdrive(archivePath, key, {sparse: false})
+    archive.isSwarming = false
     archive.replicationStreams = [] // list of all active replication streams
     archive.numPeers = 1 // num of active peers (1 for self)
     archive.manifest = null // cached manifest
@@ -266,7 +281,7 @@ module.exports = class Archiver {
   }
 
   // swarm archive
-  _swarm (archive, opts) {
+  _swarmArchive (archive, opts) {
     if (typeof archive === 'string') {
       archive = this.getArchive(archive)
       if (!archive) return
@@ -279,11 +294,11 @@ module.exports = class Archiver {
     }
 
     // close existing swarm
-    if (archive.swarm) {
+    if (archive.isSwarming) {
       archive.replicationStreams.forEach(stream => stream.destroy()) // stop all active replications
       archive.replicationStreams.length = 0
-      archive.swarm.destroy()
-      archive.swarm = null
+      archive.isSwarming = false
+      this.swarm.leave(archive.discoveryKey)
     }
 
     // done?
@@ -292,56 +307,91 @@ module.exports = class Archiver {
     }
 
     // join the swarm
-    var swarm = discoverySwarm(swarmDefaults({
+    this.swarm.join(archive.discoveryKey, { announce: !(opts.upload === false) })
+    archive.isSwarming = true
+
+    debug('Swarming archive', datEncoding.toStr(archive.key), 'discovery key', datEncoding.toStr(archive.discoveryKey))
+    archive.swarmOpts = opts
+  }
+
+  _initializeSwarm() {
+    this.swarm = discoverySwarm(swarmDefaults({
+      id: this.networkId,
       hash: false,
       utp: true,
       tcp: true,
-      stream: (info) => {
-        var key = datEncoding.toStr(archive.key)
-        var dkey = datEncoding.toStr(archive.discoveryKey)
-        var chan = dkey.slice(0, 6) + '..' + dkey.slice(-2)
-        var keyStrShort = key.slice(0, 6) + '..' + key.slice(-2)
-        debug('new connection chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort)
-
-        // create the replication stream
-        var stream = archive.replicate({
-          download: opts.download,
-          upload: opts.upload,
-          live: true
-        })
-        stream.isActivePeer = false
-        archive.replicationStreams.push(stream)
-        stream.once('close', () => {
-          var rs = archive.replicationStreams
-          var i = rs.indexOf(stream)
-          if (i !== -1) rs.splice(rs.indexOf(stream), 1)
-          archive.numPeers = countActivePeers(archive)
-        })
-
-        // timeout the connection after 5s if handshake does not occur
-        var TO = setTimeout(() => {
-          debug('handshake timeout chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort)
-          stream.destroy(new Error('Timed out waiting for handshake'))
-        }, 5000)
-        stream.once('handshake', () => {
-          stream.isActivePeer = true
-          archive.numPeers = countActivePeers(archive)
-          clearTimeout(TO)
-        })
-
-        // debugging
-        stream.on('error', err => debug('error chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort, err))
-        stream.on('close', () => debug('closing connection chan=%s type=%s host=%s key=%s', chan, info.type, info.host, keyStrShort))
-        return stream
-      }
+      stream: this._createReplicationStream.bind(this)
     }))
-    swarm.listen(this.config.datPort)
-    swarm.on('error', err => debug('Swarm error for', datEncoding.toStr(archive.key), err))
-    swarm.join(archive.discoveryKey, { announce: !(opts.upload === false) })
+    this.swarm.once('error', () => this.swarm.listen(0))
+    this.swarm.listen(DAT_SWARM_PORT)
+  }
 
-    debug('Swarming archive', datEncoding.toStr(archive.key), 'discovery key', datEncoding.toStr(archive.discoveryKey))
-    archive.swarm = swarm
-    archive.swarmOpts = opts
+  _createReplicationStream (info) {
+     // create the protocol stream
+    var connId = ++this._connIdCounter
+    var start = Date.now()
+    var stream = hypercoreProtocol({
+      id: this.networkId,
+      live: true,
+      encrypt: true
+    })
+    stream.isActivePeer = false
+    stream.peerInfo = info
+
+    const add = (dkey) => {
+      // lookup the archive
+      var dkeyStr = datEncoding.toStr(dkey)
+      var chan = dkeyStr.slice(0,6) + '..' + dkeyStr.slice(-2)
+      var archive = this.archivesByDKey[dkeyStr]
+      if (!archive) {
+        return
+      }
+
+      // ditch if we already have this stream
+      if (archive.replicationStreams.indexOf(stream) !== -1) {
+        return
+      }
+
+      // do some logging
+      var keyStr = datEncoding.toStr(archive.key)
+      var keyStrShort = keyStr.slice(0,6) + '..' + keyStr.slice(-2)
+      debug(`new connection id=${connId} key=${keyStrShort} dkey=${chan} type=${info.type} host=${info.host}:${info.port}`)
+
+      // create the replication stream
+      archive.replicate({
+        stream,
+        download: archive.swarmOpts.download,
+        upload: archive.swarmOpts.upload,
+        live: true
+      })
+      archive.replicationStreams.push(stream)
+      stream.once('close', () => {
+        var rs = archive.replicationStreams
+        var i = rs.indexOf(stream)
+        if (i !== -1) rs.splice(rs.indexOf(stream), 1)
+      })
+    }
+
+    // add the archive if the discovery network gave us any info
+    if (info.channel) {
+      add(info.channel)
+    }
+
+    // add any requested archives
+    stream.on('feed', add)
+
+    // debugging (mostly)
+    stream.once('handshake', () => {
+      stream.isActivePeer = true
+      debug(`got handshake (${Date.now() - start}ms) id=${connId} type=${info.type} host=${info.host}:${info.port}`)
+    })
+    stream.on('error', err => {
+      debug(`error (${Date.now() - start}ms) id=${connId} type=${info.type} host=${info.host}:${info.port} error=${err.toString()}`)
+    })
+    stream.on('close', err => {
+      debug(`closing connection (${Date.now() - start}ms) id=${connId} type=${info.type} host=${info.host}:${info.port}`)
+    })
+    return stream
   }
 }
 

--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -53,7 +53,7 @@ module.exports = class Archiver {
     return key in this.loadPromises
   }
 
-  async getArchiveDiskUsage (key, {forceUpdate} = {}) {
+  async getArchiveDiskUsage (key, {forceUpdate, dontUpdateUser} = {}) {
     key = datEncoding.toStr(key)
     var archive = this.getArchive(key)
     if (!archive) return 0
@@ -64,7 +64,7 @@ module.exports = class Archiver {
       archive.diskUsage = await getFolderSize(path)
 
       // if different, update the user record as well
-      if (oldUsage != archive.diskUsage) {
+      if (!dontUpdateUser && oldUsage != archive.diskUsage) {
         this.cloud.archivesDB.getByKey(key).then(archiveRecord => {
           archiveRecord.hostingUsers.forEach(async id => {
             let userRecord = await this.cloud.usersDB.getByID(id)
@@ -185,7 +185,8 @@ module.exports = class Archiver {
     // sum the disk usage of each archive
     var diskUsage = 0
     await Promise.all(userRecord.archives.map(async (archiveRecord) => {
-      diskUsage += await this.getArchiveDiskUsage(archiveRecord.key)
+      let u = await this.getArchiveDiskUsage(archiveRecord.key, {dontUpdateUser: true})
+      diskUsage += u
     }))
 
     // store on the user record

--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -28,7 +28,7 @@ module.exports = class Archiver {
     // periodically construct the indexes
     this.indexes = {popular: []}
     this._startJob(this.computePopularIndex, 'popularArchivesIndex')
-    this._startJob(this.computeUserDiskUsageAndSwarm, 'userDiskUsage')
+    this._startJob(this.computeAllUserDiskUsageAndSwarm, 'userDiskUsage')
     this._startJob(this.deleteDeadArchives, 'deleteDeadArchives')
   }
 
@@ -55,12 +55,10 @@ module.exports = class Archiver {
 
       // if different, update the user record as well
       if (oldUsage != archive.diskUsage) {
-        let diff = archive.diskUsage - oldUsage
         this.cloud.archivesDB.getByKey(key).then(archiveRecord => {
           archiveRecord.hostingUsers.forEach(async id => {
             let userRecord = await this.cloud.usersDB.getByID(id)
-            userRecord.diskUsage += diff
-            this.cloud.usersDB.update(id, {diskUsage: userRecord.diskUsage})
+            this.computeUserDiskUsageAndSwarm(userRecord)
           })
         })
       }
@@ -169,32 +167,34 @@ module.exports = class Archiver {
     }
   }
 
-  async computeUserDiskUsageAndSwarm () {
+  async computeUserDiskUsageAndSwarm (userRecord) {
+    // sum the disk usage of each archive
+    var diskUsage = 0
+    await Promise.all(userRecord.archives.map(async (archiveRecord) => {
+      diskUsage += await this.getArchiveDiskUsage(archiveRecord.key)
+    }))
+
+    // store on the user record
+    userRecord.diskUsage = diskUsage
+    await this.cloud.usersDB.update(userRecord.id, {diskUsage})
+
+    // reconfigure swarms based on quota overages
+    var quotaPct = this.config.getUserDiskQuotaPct(userRecord)
+    userRecord.archives.forEach(archiveRecord => {
+      this._swarm(archiveRecord.key, {
+        upload: true, // always upload
+        download: quotaPct < 1 // only download if the user has capacity
+      })
+    })
+  }
+
+  async computeAllUserDiskUsageAndSwarm () {
     var release = await lock('archiver-job')
     try {
       debugJobs('START Compute user quota usage')
       var start = Date.now()
       var users = await this.cloud.usersDB.list()
-      await Promise.all(users.map(async (userRecord) => {
-        // sum the disk usage of each archive
-        var diskUsage = 0
-        await Promise.all(userRecord.archives.map(async (archiveRecord) => {
-          diskUsage += await this.getArchiveDiskUsage(archiveRecord.key)
-        }))
-
-        // store on the user record
-        userRecord.diskUsage = diskUsage
-        await this.cloud.usersDB.update(userRecord.id, {diskUsage})
-
-        // reconfigure swarms based on quota overages
-        var quotaPct = this.config.getUserDiskQuotaPct(userRecord)
-        userRecord.archives.forEach(archiveRecord => {
-          this._swarm(archiveRecord.key, {
-            upload: true, // always upload
-            download: quotaPct < 1 // only download if the user has capacity
-          })
-        })
-      }))
+      await Promise.all(users.map(this.computeUserDiskUsageAndSwarm.bind(this)))
     } catch (e) {
       console.error(e)
       debugJobs('FAILED Compute user quota usage (%dms)', (Date.now() - start))
@@ -246,7 +246,7 @@ module.exports = class Archiver {
     archive.diskUsage = 0 // cached disk usage
     archive.recomputeDiskUsage = throttle(() => {
       this.getArchiveDiskUsage(archive.key, {forceUpdate: true})
-    }, ms('10s'), {trailing: true})
+    }, ms('5s'), {trailing: true})
 
     // wait for ready
     await new Promise((resolve, reject) => {

--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -1,21 +1,19 @@
-var path = require('path')
-var promisify = require('es6-promisify')
-var hyperdrive = require('hyperdrive')
-var datEncoding = require('dat-encoding')
-var discoverySwarm = require('discovery-swarm')
-var swarmDefaults = require('datland-swarm-defaults')
-var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
-var getFolderSize = require('get-folder-size')
-var ms = require('ms')
-var pda = require('pauls-dat-api')
-var lock = require('./lock')
-var debug = require('debug')('archiver')
-var debugJobs = require('debug')('jobs')
+const path = require('path')
+const promisify = require('es6-promisify')
+const hyperdrive = require('hyperdrive')
+const datEncoding = require('dat-encoding')
+const discoverySwarm = require('discovery-swarm')
+const swarmDefaults = require('datland-swarm-defaults')
+const ms = require('ms')
+const pda = require('pauls-dat-api')
+const throttle = require('lodash.throttle')
+const lock = require('./lock')
+const debug = require('debug')('archiver')
+const debugJobs = require('debug')('jobs')
 
-mkdirp = promisify(mkdirp)
-rimraf = promisify(rimraf)
-getFolderSize = promisify(getFolderSize)
+const mkdirp = promisify(require('mkdirp'))
+const rimraf = promisify(require('rimraf'))
+const getFolderSize = promisify(require('get-folder-size'))
 
 // exported api
 // =
@@ -43,6 +41,17 @@ module.exports = class Archiver {
 
   isLoadingArchive (key) {
     return key in this.loadPromises
+  }
+
+  async getArchiveDiskUsage (key, {forceUpdate} = {}) {
+    key = datEncoding.toStr(key)
+    var archive = this.getArchive(key)
+    if (!archive) return
+    if (forceUpdate || !archive.diskUsage) {
+      let path = this._getArchiveFilesPath(key)
+      archive.diskUsage = await getFolderSize(path)
+    }
+    return archive.diskUsage
   }
 
   // load archive (wrapper) manages load promises
@@ -156,11 +165,7 @@ module.exports = class Archiver {
         // sum the disk usage of each archive
         var diskUsage = 0
         await Promise.all(userRecord.archives.map(async (archiveRecord) => {
-          var path = this._getArchiveFilesPath(archiveRecord.key)
-          var archive = this.getArchive(archiveRecord.key)
-          var archiveUsage = await getFolderSize(path)
-          if (archive) archive.diskUsage = archiveUsage
-          diskUsage += archiveUsage
+          diskUsage += await this.getArchiveDiskUsage(archiveRecord.key)
         }))
 
         // store on the user record
@@ -225,6 +230,9 @@ module.exports = class Archiver {
     archive.numPeers = 1 // num of active peers (1 for self)
     archive.manifest = null // cached manifest
     archive.diskUsage = 0 // cached disk usage
+    archive.recomputeDiskUsage = throttle(() => {
+      this.getArchiveDiskUsage(archive.key, {forceUpdate: true})
+    }, ms('10s'), {trailing: true})
 
     // wait for ready
     await new Promise((resolve, reject) => {
@@ -233,6 +241,13 @@ module.exports = class Archiver {
         else resolve()
       })
     })
+
+    // wire up handlers
+    archive.metadata.on('download', archive.recomputeDiskUsage)
+    archive.on('content', () => {
+      archive.content.on('download', archive.recomputeDiskUsage)
+    })
+
     return archive
   }
 

--- a/lib/const.js
+++ b/lib/const.js
@@ -1,6 +1,7 @@
 exports.DAT_KEY_REGEX = /([0-9a-f]{64})/i
 exports.DAT_URL_REGEX = /^(dat:\/\/[0-9a-f]{64})/i
 exports.DAT_NAME_REGEX = /^([0-9a-zA-Z-]*)$/i
+exports.DAT_SWARM_PORT = 3282
 
 exports.NotFoundError = class NotFoundError extends Error {
   constructor (message) {

--- a/lib/dbs/users.js
+++ b/lib/dbs/users.js
@@ -15,6 +15,7 @@ class UsersDB extends EventEmitter {
   constructor (cloud) {
     super()
     // create levels and indexer
+    this.cloud = cloud
     this.accountsDB = sublevel(cloud.db, 'accounts', { valueEncoding: 'json' })
     this.indexDB = sublevel(cloud.db, 'accounts-index')
     this.indexer = createIndexer(this.indexDB, {
@@ -181,14 +182,20 @@ class UsersDB extends EventEmitter {
       var userRecord = await this.getByID(userId)
 
       // add/update archive
-      var archive = userRecord.archives.find(a => a.key === archiveKey)
-      if (!archive) {
-        archive = Object.assign({}, UsersDB.archiveDefaults())
-        archive.key = archiveKey
-        if (typeof name !== 'undefined') archive.name = name
-        userRecord.archives.push(archive)
+      var archiveRecord = userRecord.archives.find(a => a.key === archiveKey)
+      if (!archiveRecord) {
+        archiveRecord = Object.assign({}, UsersDB.archiveDefaults())
+        archiveRecord.key = archiveKey
+        if (typeof name !== 'undefined') archiveRecord.name = name
+        userRecord.archives.push(archiveRecord)
       } else {
-        if (typeof name !== 'undefined') archive.name = name
+        if (typeof name !== 'undefined') archiveRecord.name = name
+      }
+
+      // update disk usage
+      var archive = this.cloud.archiver.getArchive(archiveKey)
+      if (archive && archive.diskUsage) {
+        userRecord.diskUsage += archive.diskUsage
       }
 
       // update records
@@ -211,6 +218,12 @@ class UsersDB extends EventEmitter {
         return // not already hosting
       }
       userRecord.archives.splice(index, 1)
+
+      // update disk usage
+      var archive = this.cloud.archiver.getArchive(archiveKey)
+      if (archive && archive.diskUsage) {
+        userRecord.diskUsage -= archive.diskUsage
+      }
 
       // update records
       await this.put(userRecord)

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ class Hypercloud {
     }).on('end', async () => {
       await Promise.all(ps)
       // compute user disk usage and swarm archives accordingly
-      this.archiver.computeUserDiskUsageAndSwarm()
+      this.archiver.computeAllUserDiskUsageAndSwarm()
       // create the popular-archives index
       this.archiver.computePopularIndex()
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       "integrity": "sha1-YmfHtgpR+sRzRns8SgLNHkQYBf4="
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.45",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.45.tgz",
-      "integrity": "sha1-cbsfh9cYdILQ2IUfWylEWOHHhmc="
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.46.tgz",
+      "integrity": "sha512-dtJos9GpTYqX/LBvpu8xHxOQTeAXEgFzZkQmcLgxj/ZbNv0v+cpM3A2ZAiOljgNAbHeguPivFn2wHbNYvLJVcA=="
     },
     "@types/mime": {
       "version": "0.0.29",
@@ -24,9 +24,9 @@
       "integrity": "sha1-+8/TMFc7kS71nu7hRgK/rOYwdUs="
     },
     "@types/node": {
-      "version": "7.0.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.29.tgz",
-      "integrity": "sha512-+8JrLZny/uR+d/jLK9eaV63buRM7X/gNzQk57q76NS4KNKLSKOmxJYFIlwuP2zDvA7wqZj05POPhSd9Z1hYQpQ=="
+      "version": "7.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.31.tgz",
+      "integrity": "sha512-+KrE1LDddn97ip+gXZAnzNQ0pupKH/6tcKwTpo96BDVNpzmhIKGHug0Wd3H0dN4WEqYB1tXYI5m2mZuIZNI8tg=="
     },
     "@types/serve-static": {
       "version": "1.7.31",
@@ -298,9 +298,9 @@
       "integrity": "sha1-cOQDePMEBtG3hPWx8mXwIUr2mxc="
     },
     "aws-sdk": {
-      "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.67.0.tgz",
-      "integrity": "sha1-wPw6Q0PPxjEmXZ3WvFC6cJQB+Fc="
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.68.0.tgz",
+      "integrity": "sha1-m60xNbMfqCvnKlmFGJo3rucMaUA="
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -731,14 +731,19 @@
       "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ=="
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
       "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q="
+    },
+    "base64-to-uint8array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64-to-uint8array/-/base64-to-uint8array-1.0.0.tgz",
+      "integrity": "sha512-drjWQcees55+XQSVHYxiUF05Fj6ko3XJUoxykZEXbm0BMmNz2ieWiZGJ+6TFWnjN2saucG6pI13LS92O4kaiAg=="
     },
     "base64url": {
       "version": "2.0.0",
@@ -796,9 +801,14 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
     },
     "blake2b": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-1.2.0.tgz",
-      "integrity": "sha1-ynWs/jGh9wvCj5/dm2CyFzHgnzg="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.2.tgz",
+      "integrity": "sha1-aIDt3KNc/t6SxPsnJCITNPmJFFo="
+    },
+    "blake2b-wasm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-1.1.2.tgz",
+      "integrity": "sha512-iRWsWGM5fsTnjrEW/1mnYHmBqGfwZJ1MxsEtMuv2Z/ZKilfUY2iJTYiLUlRzRyJGuH+BBCD0uROGUi2464JE8w=="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -844,9 +854,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
     },
     "braces": {
       "version": "1.8.5",
@@ -1423,9 +1433,9 @@
       }
     },
     "discovery-swarm": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-4.3.8.tgz",
-      "integrity": "sha1-bOlc+TR1fIW0DPL/upUPHRwyMcc=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/discovery-swarm/-/discovery-swarm-4.4.0.tgz",
+      "integrity": "sha512-oRT9RCrMtbC5fUTa71WCBG6nxxy3LFVkTs/YYU82TTErUL+Zn+/19jyml4LhuhLoImHn0z8Um3MOFkDo7MEZdg==",
       "dev": true
     },
     "dns-discovery": {
@@ -2834,9 +2844,9 @@
       "integrity": "sha1-7DAz5lX9LSUCE93rgaUBbZP6Vp0="
     },
     "hypercore": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.5.0.tgz",
-      "integrity": "sha1-Wlqr6nq83zVzAzk7D54O5LdVtfA="
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.6.0.tgz",
+      "integrity": "sha512-YwqBMj59XfisCdhdRa2CT/ChHoOxgOVxR2oMBArDBUh+xQC/QZ6+J12vkCHPKnnSD1JYKTe9pvGAcTrmi2GibQ=="
     },
     "hypercore-protocol": {
       "version": "6.4.0",
@@ -2844,9 +2854,9 @@
       "integrity": "sha1-iXpvoLeSa0iZXdp+A9qtB31jODg="
     },
     "hyperdrive": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.3.0.tgz",
-      "integrity": "sha1-QsYs7vXgUXcJNt8MBmfBJpXxX9o="
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/hyperdrive/-/hyperdrive-9.4.0.tgz",
+      "integrity": "sha512-EOCbUgUd4AKYeFGSTFhDmVIcxATse2KcTIDXvKb89HBBqypv96FAMacu6/bg0nHZIi6bAXKN3mCH7GJ3IMA7Wg=="
     },
     "hyperdrive-duplicate": {
       "version": "2.0.0",
@@ -2892,9 +2902,9 @@
       "dev": true
     },
     "image-size": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.4.tgz",
-      "integrity": "sha1-lOB77sBlk4bxrvuEsiIuiEBUhc0=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "optional": true
     },
     "immediate": {
@@ -3638,9 +3648,9 @@
       "integrity": "sha1-6n+4VG2DczOWoTCR12z+tMBoN9U="
     },
     "lru-cache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
-      "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew=="
     },
     "ltgt": {
       "version": "2.1.3",
@@ -3847,6 +3857,11 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
       "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "nanoassert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.0.0.tgz",
+      "integrity": "sha1-VVoRIL8mXh0zMy73tYA3ENXiCv8="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4121,9 +4136,9 @@
       "dev": true
     },
     "pauls-dat-api": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/pauls-dat-api/-/pauls-dat-api-4.2.1.tgz",
-      "integrity": "sha1-UrHP2DPfvr0OGr9cFxQh7vvOYxo="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/pauls-dat-api/-/pauls-dat-api-4.2.3.tgz",
+      "integrity": "sha512-wiOZ1UX5FEOSFICKwdOukMqqv10sfITpIYqY/wPXIKrOb0E7P+GvURkN6Y51PP3rPV3EqFr737Kuf0Oebv9rzw=="
     },
     "pauls-embedded-analytics": {
       "version": "1.2.0",
@@ -4411,14 +4426,14 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-      "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dependencies": {
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8="
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc="
         }
       }
     },
@@ -4791,6 +4806,11 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s="
     },
+    "siphash24": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.0.1.tgz",
+      "integrity": "sha512-jvnaIMdphdYIlniZI0oLW5BAOtr0wE51/mchhMwUP94IzIKMIjjO4TJQNakwxAbGBosuiBORsfmbeYArgZrVpA=="
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -4829,9 +4849,9 @@
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE="
     },
     "sodium-javascript": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.2.0.tgz",
-      "integrity": "sha1-FJ48b1aaoWdtYUgOm0BbOGq+Tik="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.3.1.tgz",
+      "integrity": "sha512-2uSssD4aJ7OmUdeG5vtdLJQyM2oGniUUEYW1XM+kQt4c3OXytOKmX6UIpae9Dviqx9DutNwF6U0VrMqDE19bfQ=="
     },
     "sodium-native": {
       "version": "1.10.1",
@@ -4844,9 +4864,9 @@
       "integrity": "sha1-MDdtdX2ozLFe78Q7d1sbj56rCF0="
     },
     "sodium-universal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.1.0.tgz",
-      "integrity": "sha1-+CVJS3U0Xc37bLvsHT4T/8lXryM="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.2.0.tgz",
+      "integrity": "sha512-v6nxuxtjJEaofjkYF5O2AZu2wikrGEX/hWAERUen5auZdR9QsTlEgsuypQDwkVe/R4uhT6hNm0yZDwXUOiVKBw=="
     },
     "sort-keys": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -298,9 +298,9 @@
       "integrity": "sha1-cOQDePMEBtG3hPWx8mXwIUr2mxc="
     },
     "aws-sdk": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.65.0.tgz",
-      "integrity": "sha1-+z7h1WURT2mhqbsjEbgptZx8bo8="
+      "version": "2.67.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.67.0.tgz",
+      "integrity": "sha1-wPw6Q0PPxjEmXZ3WvFC6cJQB+Fc="
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -318,14 +318,14 @@
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
     },
     "babel-core": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
-      "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk="
     },
     "babel-generator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-      "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw="
     },
     "babel-helper-bindify-decorators": {
       "version": "6.24.1",
@@ -711,24 +711,24 @@
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs="
     },
     "babel-template": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-      "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE="
     },
     "babel-traverse": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-      "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE="
     },
     "babel-types": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-      "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU="
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4="
     },
     "babylon": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
-      "integrity": "sha1-IB0l71+JLEG65JSIsI2w3Udun1w="
+      "version": "6.17.3",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
+      "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ=="
     },
     "balanced-match": {
       "version": "0.4.2",
@@ -795,10 +795,10 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4="
     },
-    "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    "blake2b": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-1.2.0.tgz",
+      "integrity": "sha1-ynWs/jGh9wvCj5/dm2CyFzHgnzg="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -1285,9 +1285,9 @@
       "dev": true
     },
     "dat-storage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dat-storage/-/dat-storage-1.0.2.tgz",
-      "integrity": "sha1-460px5JZW3MS9+erIzkWnJsSr0c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dat-storage/-/dat-storage-1.0.3.tgz",
+      "integrity": "sha512-6qTeWDLCbn4DG5NmTSnCAikivjXXn5ukMLafEbqBn/15zcqdpNgsOx/QnCqXdDoAeP1WWXjJp3GBDtls/et3bA==",
       "dev": true
     },
     "dat-swarm-defaults": {
@@ -1461,9 +1461,9 @@
       "dev": true
     },
     "dns-socket": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.1.tgz",
-      "integrity": "sha1-P5spxDGEszMshW6cNKamv3N1a70=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-1.6.2.tgz",
+      "integrity": "sha512-Ztbaf5fToBfm/4+sVEJi7mT2mJOLYYpI+TpgOhxwp5l28UwunTpHMccVhTe9L0F6pQ2cUF0ja9ukuTCtzYq2Ig==",
       "dev": true
     },
     "dns-txt": {
@@ -3189,12 +3189,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
-    "jodid25519": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
-    },
     "joi": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
@@ -3508,9 +3502,9 @@
       }
     },
     "leveldown": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.1.tgz",
-      "integrity": "sha512-q2yI2JFtX3L+83tGqWG2gJhENEbdVuzDAPUvMVPxoKtnFaeeD2E/l0OANOtZOxhXnCk5mnNFao59KYmfJLPkJg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
+      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.1",
@@ -3610,6 +3604,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.zipobject": {
       "version": "4.1.3",
@@ -4127,9 +4126,9 @@
       "integrity": "sha1-UrHP2DPfvr0OGr9cFxQh7vvOYxo="
     },
     "pauls-embedded-analytics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pauls-embedded-analytics/-/pauls-embedded-analytics-1.0.0.tgz",
-      "integrity": "sha512-LbbnrYYsYzbEpCbr3dhg4RykiuPqVz0JTJ8yC99XKMJFHKz85lSkJr+eH9qRuCK0cBYQlFywsLzFNLNxtBmO8Q=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pauls-embedded-analytics/-/pauls-embedded-analytics-1.2.0.tgz",
+      "integrity": "sha512-7/V9B74TvN1HuD6pwtWKf4nL0B50lk5KyC8qgp2ogS0o3BFDJQbKGX4KnEQoQ/bM6SYY/yqNQcomC4dH6kii8Q=="
     },
     "performance-now": {
       "version": "0.2.0",
@@ -4401,9 +4400,9 @@
       }
     },
     "random-access-file": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-1.7.3.tgz",
-      "integrity": "sha1-5eZCy4XfwTFmv+qpf3/8n1YJBT0="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-1.8.1.tgz",
+      "integrity": "sha512-+Uhk0Of+dWHWjpbL2hizcwSV1UomcN3S0iUGV6BTZ2Js1BP9jHx3E5CT7y0eLbqTQNkVi4iehkHmia7Mdqa47w=="
     },
     "random-access-memory": {
       "version": "2.4.0",
@@ -4830,9 +4829,9 @@
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE="
     },
     "sodium-javascript": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.0.1.tgz",
-      "integrity": "sha1-LnCLXQPZrdi2hQFN96r5C4Y81Eg="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.2.0.tgz",
+      "integrity": "sha1-FJ48b1aaoWdtYUgOm0BbOGq+Tik="
     },
     "sodium-native": {
       "version": "1.10.1",
@@ -4845,9 +4844,9 @@
       "integrity": "sha1-MDdtdX2ozLFe78Q7d1sbj56rCF0="
     },
     "sodium-universal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.0.0.tgz",
-      "integrity": "sha1-CMdBTulhUza1ImCaXASgnuDj//w="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-1.1.0.tgz",
+      "integrity": "sha1-+CVJS3U0Xc37bLvsHT4T/8lXryM="
     },
     "sort-keys": {
       "version": "1.1.2",
@@ -5582,9 +5581,9 @@
       }
     },
     "sshpk": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-      "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "get-folder-size": "^1.0.0",
     "greenlock-express": "^2.0.11",
     "hypercloud-ui-vanilla": "^1.0.0",
-    "hyperdrive": "^9.3.0",
+    "hyperdrive": "^9.4.0",
     "identify-filetype": "^1.0.0",
     "js-yaml": "^3.8.4",
     "jsonwebtoken": "^7.4.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "level": "^1.7.0",
     "level-promise": "^2.1.1",
     "level-simple-indexes": "^2.2.0",
+    "lodash.throttle": "^4.1.1",
     "lru": "^3.1.0",
     "mime": "^1.3.6",
     "mkdirp": "^0.5.1",

--- a/test/archives.js
+++ b/test/archives.js
@@ -134,7 +134,7 @@ test('read back archive', async t => {
 
 test('user disk usage is now non-zero', async t => {
   // run usage-compute job
-  await app.cloud.archiver.computeUserDiskUsageAndSwarm()
+  await app.cloud.archiver.computeAllUserDiskUsageAndSwarm()
 
   // check data
   var res = await app.req.get({url: '/v1/account', json: true, auth})

--- a/test/quotas.js
+++ b/test/quotas.js
@@ -117,18 +117,6 @@ test.cb('check archive status and wait till synced', t => {
   }
 })
 
-test('archive is still downloading', async t => {
-  // check archive record
-  var res = await app.req.get({url: `/v1/admin/archives/${testDatKey}`, json: true, auth})
-  t.is(res.statusCode, 200, '200 got archive data')
-  t.deepEqual(res.body.swarmOpts, {upload: true, download: true}, 'is still downloading')
-})
-
-test('compute disk usage', async t => {
-  // run usage-compute job
-  await app.cloud.archiver.computeUserDiskUsageAndSwarm()
-})
-
 test('user disk usage now exceeds the disk quota', async t => {
   // check user record
   var res = await app.req.get({url: '/v1/admin/users/bob', json: true, auth})


### PR DESCRIPTION
 - [x] Recount archive disk usage more frequently (uses throttled 'download' events)
 - [x] Adjust user disk-usage when archive disk-usage is recounted
 - [x] Adjust user disk-usage when archives are added (existing count)
 - [x] Adjust user disk-usage when archives are removed
 - [x] Adjust swarms when user disk-usage is recalculated
 - [x] Fix: read-only swarm mode doesnt work yet
 - [ ] ~~Fix: don't allocate disk space for files about to be downloaded~~ (wontfix: this is a macOS-only issue)
 - [x] Fix: refactor the discovery-swarm to use only one instance