### PR TITLE
Add 'resend confirmation email' admin tool

### DIFF
--- a/assets/html/admin-dashboard-user.html
+++ b/assets/html/admin-dashboard-user.html
@@ -30,6 +30,12 @@
               <button id="suspend-btn" class="btn big">Suspend</button>
             <% } %>
           </div>
+          <br>
+          <div>
+            <% if (!user.isEmailVerified) { %>
+              <button id="resend-email-confirmation-btn" class="btn big">Resend confirmation email</button>
+            <% } %>
+          </div>
         </div>
       </div>
 

--- a/assets/js/admin-dashboard-user.js
+++ b/assets/js/admin-dashboard-user.js
@@ -42,6 +42,15 @@ $(function () {
       .done(onUpdate)
       .fail(onError)
   })
+
+  // resend confirmation email
+  $('#resend-email-confirmation-btn').on('click', function () {
+    if (!confirm('Resend confirmation email?')) return
+    $('#error-general').text('')
+    $.ajax(location.pathname + '/resend-email-confirmation', {method: 'post', contentType: 'application/json; charset=utf-8', data: JSON.stringify({_csrf})})
+      .done(onUpdate)
+      .fail(onError)
+  })
 })
 
 function onUpdate () {

--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ module.exports = function (config) {
   app.post('/v1/admin/users/:id', cloud.api.admin.updateUser)
   app.post('/v1/admin/users/:id/suspend', cloud.api.admin.suspendUser)
   app.post('/v1/admin/users/:id/unsuspend', cloud.api.admin.unsuspendUser)
+  app.post('/v1/admin/users/:id/resend-email-confirmation', cloud.api.admin.resendEmailConfirmation)
   app.post('/v1/admin/users/:username/send-email', cloud.api.admin.sendEmail)
   app.post('/v1/admin/archives/:key/feature', cloud.api.admin.featureArchive)
   app.post('/v1/admin/archives/:key/unfeature', cloud.api.admin.unfeatureArchive)

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -1,5 +1,7 @@
+const querystring = require('querystring')
 const {NotFoundError, UnauthorizedError, ForbiddenError, ADMIN_MODIFIABLE_FIELDS} = require('../const')
 const lock = require('../lock')
+const {randomBytes} = require('../crypto')
 
 // exported api
 // =
@@ -251,6 +253,37 @@ module.exports = class AdminAPI {
       username,
       brandname: this.config.brandname
     })
+    res.status(200).end()
+  }
+
+  async resendEmailConfirmation (req, res) {
+    // check perms
+    if (!res.locals.session) throw new UnauthorizedError()
+    if (!res.locals.session.scopes.includes('admin:users')) throw new ForbiddenError()
+
+    // generate email verification nonce
+    let emailVerificationNonce = (await randomBytes(32)).toString('hex')
+
+    // update user
+    var userRecord = await this.usersDB.update(req.params.id, {emailVerificationNonce})
+
+    // send email
+    var qs = querystring.stringify({
+      username: userRecord.username, nonce: emailVerificationNonce
+    })
+    this.mailer.send('verification', {
+      email: userRecord.email,
+      username: userRecord.username,
+      emailVerificationNonce,
+      emailVerificationLink: `https://${this.config.hostname}/v1/verify?${qs}`
+    })
+    // log the verification link
+    if (this.config.env === 'development') {
+      console.log('Verify link for', userRecord.username)
+      console.log(`https://${this.config.hostname}/v1/verify?${qs}`)
+    }
+
+    // respond
     res.status(200).end()
   }
 


### PR DESCRIPTION
Lets admins resend the email confirmation, which I imagine will be a common issue while debugging issues of the signup flow