### PR TITLE
Fixes linting in zepto-patches

### DIFF
--- a/assets/js/zepto-patches.js
+++ b/assets/js/zepto-patches.js
@@ -1,8 +1,16 @@
+/* global $:false */
 {
   // monkey-patch $.post so that it always sends JSON
   function parseArguments (url, data, success, dataType) {
-    if ($.isFunction(data)) dataType = success, success = data, data = undefined
-    if (!$.isFunction(success)) dataType = success, success = undefined
+    if ($.isFunction(data)) {
+      dataType = success
+      success = data
+      data = undefined
+    }
+    if (!$.isFunction(success)) {
+      dataType = success
+      success = undefined
+    }
     return {
       url: url,
       data: data,


### PR DESCRIPTION
In order to not feel uncomfortable with the ✖︎ in the PR's and commits this PR fixes the style of the `./assets/js/zepto-patches.js` file as it seems to be the only file broken in the linter