### PR TITLE
Allowed to run lint separate of test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "install-transpiler": "npm install babel-preset-es2015",
     "start": "node bin.js",
-    "test": "ava test/*.js && standard"
+    "test": "npm run unit && npm run lint",
+    "unit": "ava test/*.js",
+    "lint": "standard"
   },
   "keywords": [
     "hyperdrive",


### PR DESCRIPTION
Sometimes some linting error occurs and to quickly see if the change fixed all errors its good to have linting / unit tests available as separate npm scripts. This PR splits the `npm test` script in the scripts to the package.json.