### PR TITLE
WIP: Add support for custom domains

### DIFF
--- a/assets/html/archive.html
+++ b/assets/html/archive.html
@@ -39,6 +39,19 @@
               <p><em>No description</em></p>
             <% } %>
 
+            <% if (isOwner || (sessionUser && sessionUser.scopes.includes('admin:dats'))) { %>
+              <div>
+                <form id="custom-domain-form" action="/v1/archives/domain" method="POST">
+                  <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                  <input name="key" type="hidden" value="<%= key %>"/>
+                  <input type="text" name="domain" value="<%= domain %>"/>
+                  <button type="submit" id="custom-domain-archive" class="btn outline">
+                    Set domain
+                  </button>
+                </form>
+              </div>
+            <% } %>
+
             <% if (isOwner) { %>
               <div>
                 <button id="show-remove-archive-form" class="link">Remove archive</button>

--- a/assets/js/archive.js
+++ b/assets/js/archive.js
@@ -1,8 +1,9 @@
-/* global $ */
+/* global $ params */
 
 // archive page js
 $(function () {
   var removeForm = $('#remove-archive-form')
+  var customDomainForm = $('#custom-domain-form')
   var urlBtns = $('.link-btns .label')
 
   urlBtns.forEach(function (el) {
@@ -43,12 +44,41 @@ $(function () {
     })
   })
 
+  customDomainForm.on('submit', function (e) {
+    e.preventDefault()
+
+    // serialize form values
+    var values = {}
+    $(this).serializeArray().forEach(function (value) {
+      values[value.name] = value.value
+    })
+
+    var xhr = $.post('/v1/admin/archives/' + params.key + '/domain', values)
+    xhr.done(function (res) {
+      // success, redirect
+      renderSuccess({message: 'Custom domain saved.'})
+    })
+
+    xhr.fail(function (res) {
+      // failure, render errors
+      try {
+        renderErrors(JSON.parse(res.responseText))
+      } catch (e) {
+        renderErrors(res.responseText)
+      }
+    })
+  })
+
   function updateActiveURL (e) {
     urlBtns.forEach(function (el) {
       el.classList.remove('selected')
     })
 
     e.target.classList.add('selected')
+  }
+
+  function renderSuccess (json) {
+    $('#feedback-general').text(json.message || json)
   }
 
   function renderErrors (json) {

--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -2,6 +2,7 @@ const {NotFoundError} = require('../const')
 const pda = require('pauls-dat-api')
 const parseRange = require('range-parser')
 const {identifyStream} = require('../helpers')
+
 const directoryListingPage = require('../templates/directory-listing-page')
 const joinPaths = require('path').join
 
@@ -14,53 +15,63 @@ module.exports = class ArchiveFilesAPI {
     this.usersDB = cloud.usersDB
     this.archivesDB = cloud.archivesDB
     this.archiver = cloud.archiver
+    this.customDomainsDB = cloud.customDomainsDB
   }
 
   async _getArchiveRecord (req, {topLevel} = {}) {
     var username, archname, userRecord, archiveRecord
     const findFn = test => a => a.name.toLowerCase() === test
 
-    if (this.config.sites === 'per-archive') {
-      let vhostParts = req.vhost[0].split('-')
-      if (vhostParts.length === 1) {
-        // user.domain
-        username = archname = vhostParts[0]
-      } else {
-        // archive-user.domain
-        archname = vhostParts.slice(0, -1).join('-')
-        username = vhostParts[vhostParts.length - 1]
-      }
+    var host = req.vhost ? req.vhost.host : req.hostname
 
-      // lookup user record
-      userRecord = await this.usersDB.getByUsername(username)
-      if (!userRecord) throw new NotFoundError()
+    if (host.indexOf(this.config.hostname) > -1) {
+      if (this.config.sites === 'per-archive') {
+        let vhostParts = host.split('.')[0].split('-')
+        if (vhostParts.length === 1) {
+          // user.domain
+          username = archname = vhostParts[0]
+        } else {
+          // archive-user.domain
+          archname = vhostParts.slice(0, -1).join('-')
+          username = vhostParts[vhostParts.length - 1]
+        }
 
-      // lookup archive record
-      archiveRecord = userRecord.archives.find(findFn(archname))
-      if (!archiveRecord) throw new NotFoundError()
-      return archiveRecord
-    } else {
-      // user.domain/archive
-      username = req.vhost[0]
-      archname = req.path.split('/')[1]
+        // lookup user record
+        userRecord = await this.usersDB.getByUsername(username)
+        if (!userRecord) throw new NotFoundError()
 
-      // lookup user record
-      userRecord = await this.usersDB.getByUsername(username)
-      if (!userRecord) throw new NotFoundError()
-
-      if (!topLevel && archname) {
         // lookup archive record
         archiveRecord = userRecord.archives.find(findFn(archname))
-        if (archiveRecord) {
-          archiveRecord.isNotToplevel = true
-          return archiveRecord
-        }
-      }
+        if (!archiveRecord) throw new NotFoundError()
+        return archiveRecord
+      } else {
+        // user.domain/archive
+        username = host.split('.')[0]
+        archname = req.path.split('/')[1]
 
-      // look up archive record at username
-      archiveRecord = userRecord.archives.find(findFn(username))
-      if (!archiveRecord) throw new NotFoundError()
-      return archiveRecord
+        // lookup user record
+        userRecord = await this.usersDB.getByUsername(username)
+        if (!userRecord) throw new NotFoundError()
+
+        if (!topLevel && archname) {
+          // lookup archive record
+          archiveRecord = userRecord.archives.find(findFn(archname))
+          if (archiveRecord) {
+            archiveRecord.isNotToplevel = true
+            return archiveRecord
+          }
+        }
+
+        // look up archive record at username
+        archiveRecord = userRecord.archives.find(findFn(username))
+        if (!archiveRecord) throw new NotFoundError()
+        return archiveRecord
+      }
+    } else {
+      var archive = await this.customDomainsDB.getByDomain(host)
+      if (archive) {
+        return archive
+      }
     }
   }
 

--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -12,6 +12,7 @@ module.exports = class ArchivesAPI {
     this.usersDB = cloud.usersDB
     this.archivesDB = cloud.archivesDB
     this.activityDB = cloud.activityDB
+    this.customDomainsDB = cloud.customDomainsDB
     this.archiver = cloud.archiver
   }
 
@@ -265,6 +266,34 @@ module.exports = class ArchivesAPI {
     var need = metadata.length + content.length
     var remaining = blocksRemaining(metadata) + blocksRemaining(content)
     return (need - remaining) / need
+  }
+
+  async addCustomDomain (req, res) {
+    // check perms
+    // FIXME: What checks do we need here exactly to check if the one adding the domain is the owner of the archive?
+    if (!res.locals.session) throw new UnauthorizedError()
+    // if (!res.locals.session.scopes.includes('admin:dats')) throw new ForbiddenError()
+    if (!res.locals.session.scopes.includes('user')) throw new ForbiddenError()
+    req.checkBody('key').optional().isDatHash()
+
+    var {domain, key} = req.body
+    // update db
+
+    await this.customDomainsDB.add({key: key, domain: domain})
+    res.status(200).end()
+  }
+  async removeCustomDomain (req, res) {
+    // check perms
+    // FIXME: What checks do we need here exactly to check if the one removing the domain is the owner of the archive?
+    if (!res.locals.session) throw new UnauthorizedError()
+    if (!res.locals.session.scopes.includes('user')) throw new ForbiddenError()
+    // if (!res.locals.session.scopes.includes('admin:dats')) throw new ForbiddenError()
+    req.checkBody('key').optional().isDatHash()
+
+    var {key} = req.body
+    // update db
+    await this.customDomainsDB.remove(key)
+    res.status(200).end()
   }
 }
 

--- a/lib/apis/user-content.js
+++ b/lib/apis/user-content.js
@@ -48,6 +48,8 @@ class UserContentAPI {
     // load additional data
     var isFeatured = await this.cloud.featuredArchivesDB.has(archive.key)
 
+    var domain = await this.cloud.customDomainsDB.getDomain(archive.key)
+
     res.render('archive', {
       username,
       key: archive.key,
@@ -60,6 +62,7 @@ class UserContentAPI {
       progress: (progress * 100) | 0,
       diskUsage: archive.diskUsage,
       isOwner,
+      domain,
       csrfToken: req.csrfToken()
     })
   }

--- a/lib/dbs/custom-domains.js
+++ b/lib/dbs/custom-domains.js
@@ -1,0 +1,103 @@
+const assert = require('assert')
+const levelPromise = require('level-promise')
+var createIndexer = require('level-simple-indexes')
+const sublevel = require('subleveldown')
+const collect = require('stream-collector')
+var { promisifyModule } = require('../helpers')
+
+// exported api
+// =
+
+class CustomDomainsDB {
+  constructor (cloud) {
+    // create levels and indexer
+
+    this.archivesDB = cloud.archivesDB
+    this.indexDB = sublevel(cloud.db, 'custom-domains-index')
+    this.customDomainsDB = sublevel(cloud.db, 'custom-domains', { valueEncoding: 'json' })
+
+    this.indexer = createIndexer(this.indexDB, {
+      keyName: 'key',
+      properties: ['domain'],
+      map: (key, next) => {
+        this.getByKey(key)
+          .catch(next)
+          .then(res => next(null, res))
+      }
+    })
+
+    // promisify
+    levelPromise.install(this.customDomainsDB)
+    levelPromise.install(this.indexDB)
+    promisifyModule(this.indexer, ['findOne', 'addIndexes', 'removeIndexes', 'updateIndexes'])
+
+    // connect to archives emitters
+    cloud.archivesDB.on('del', this.onArchiveDel.bind(this))
+  }
+
+  // event handlers
+  //
+
+  onArchiveDel (record) {
+    this.remove(record.key)
+  }
+
+  // basic ops
+  // =
+
+  async add (record) {
+    assert(typeof record.key === 'string')
+    assert(typeof record.domain === 'string')
+    await this.customDomainsDB.put(record.key, record)
+    await this.indexer.updateIndexes(record)
+  }
+
+  async remove (key) {
+    assert(typeof key === 'string')
+    await this.customDomainsDB.del(key)
+  }
+
+  // getters
+  // =
+
+  async getByKey (key) {
+    assert(typeof key === 'string')
+    try {
+      return await this.customDomainsDB.get(key)
+    } catch (e) {
+      if (e.notFound) return null
+      throw e
+    }
+  }
+
+  async getByDomain (domain) {
+    assert(typeof domain === 'string')
+    return this.indexer.findOne('domain', domain)
+  }
+
+  async getDomain (key) {
+    var record = await this.getByKey(key)
+    return record ? record.domain : null
+  }
+
+  async has (key) {
+    assert(typeof key === 'string')
+    try {
+      await this.customDomainsDB.get(key)
+      return true // if it doesnt fail, the key exists
+    } catch (e) {
+      return false
+    }
+  }
+
+  async list () {
+    var keys = await new Promise((resolve, reject) => {
+      collect(this.customDomainsDB.createValueStream(), (err, res) => {
+        if (err) reject(err)
+        else resolve(res)
+      })
+    })
+    return keys
+  }
+}
+module.exports = CustomDomainsDB

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ const ArchivesDB = require('./dbs/archives')
 const ActivityDB = require('./dbs/activity')
 const ReportsDB = require('./dbs/reports')
 const FeaturedArchivesDB = require('./dbs/featured-archives')
+const CustomDomainsDB = require('./dbs/custom-domains')
 
 class Hypercloud {
   constructor (config) {
@@ -71,6 +72,7 @@ class Hypercloud {
     this.archivesDB = new ArchivesDB(this)
     this.activityDB = new ActivityDB(this)
     this.featuredArchivesDB = new FeaturedArchivesDB(this)
+    this.customDomainsDB = new CustomDomainsDB(this)
     this.reportsDB = new ReportsDB(this)
     this.sessions = new Sessions(this)
 


### PR DESCRIPTION
Changes:
- change the main app handling - make the default behaviour of hashbase to serve archives, and the dashboard/website a specific vhost. This allows hashbase to work with any domain that points to it.
- add support to the API to add/remove custom domains
- add UI elements to add/remove custom domains
- add a custom domains DB where the relation between domain / dat is stored

Questions:
- What information should we store for a domain in the custom domains DB? dat -> domain? Or should we add user / archivename as well so we can verify that with the CNAME?
- How can we verify that a user is the owner of a domain?
