### PR TITLE
Allow requesting html or text responses for directory listings over http

### DIFF
--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -108,7 +108,7 @@ module.exports = class ArchiveFilesAPI {
       // apply the web_root config
       if (manifest && manifest.web_root) {
         if (path) {
-           path = joinPaths(manifest.web_root, path)
+          path = joinPaths(manifest.web_root, path)
         } else {
           path = manifest.web_root
         }
@@ -141,10 +141,34 @@ module.exports = class ArchiveFilesAPI {
 
     // handle folder
     if (entry && entry.isDirectory()) {
-      res.writeHead(200, 'OK', {
-        'Content-Type': 'text/html'
+      var type = req.accepts(['json', 'text', 'html'])
+
+      // If the client asked for text or didn't specify serve text
+      if (type === 'text') {
+        res.writeHead(200, 'OK', {
+          'Content-Type': 'text/plain'
+        })
+        return res.end(await directoryListingPage.text(archive, filepath, manifest && manifest.web_root))
+      }
+      // If the client asked for html serve html.
+      if (type === 'html') {
+        res.writeHead(200, 'OK', {
+          'Content-Type': 'text/html'
+        })
+        return res.end(await directoryListingPage.html(archive, filepath, manifest && manifest.web_root))
+      }
+      // If the client asked for json serve json.
+      if (type === 'json') {
+        res.writeHead(200, 'OK', {
+          'Content-Type': 'application/json'
+        })
+        return res.end(await directoryListingPage.json(archive, filepath, manifest && manifest.web_root))
+      }
+      // We could not negotiate a type with the client
+      res.writeHead(406, 'Not Acceptable', {
+        'Content-Type': 'text/plain'
       })
-      return res.end(await directoryListingPage(archive, filepath, manifest && manifest.web_root))
+      return res.end('Accept must be text/plain, text/html, or application/json\n')
     }
 
     // handle not found

--- a/lib/templates/directory-listing-page.js
+++ b/lib/templates/directory-listing-page.js
@@ -2,6 +2,11 @@ const path = require('path')
 const {pluralize, makeSafe} = require('../helpers')
 const {stat, readdir} = require('pauls-dat-api')
 
+exports = module.exports = renderDirectoryListingPageHtml
+exports.html = renderDirectoryListingPageHtml
+exports.json = renderDirectoryListingPageJson
+exports.text = renderDirectoryListingPageText
+
 const styles = `<style>
   .entry {
     background: no-repeat center left;
@@ -19,7 +24,7 @@ const styles = `<style>
   }
 </style>`
 
-module.exports = async function renderDirectoryListingPage (archive, dirPath) {
+async function getEntries (archive, dirPath) {
   // list files
   var names = []
   try { names = await readdir(archive, dirPath) } catch (e) {}
@@ -36,13 +41,21 @@ module.exports = async function renderDirectoryListingPage (archive, dirPath) {
   entries = entries.filter(Boolean)
 
   // sort the listing
-  entries.sort((a, b) => {
-    // directories on top
-    if (a.isDirectory() && !b.isDirectory()) return -1
-    if (!a.isDirectory() && b.isDirectory()) return 1
-    // alphabetical after that
-    return a.name.localeCompare(b.name)
-  })
+  entries.sort(sortEntries)
+
+  return entries
+}
+
+function sortEntries (a, b) {
+  // directories on top
+  if (a.isDirectory() && !b.isDirectory()) return -1
+  if (!a.isDirectory() && b.isDirectory()) return 1
+  // alphabetical after that
+  return a.name.localeCompare(b.name)
+}
+
+async function renderDirectoryListingPageHtml (archive, dirPath) {
+  var entries = await getEntries(archive, dirPath)
 
   // show the updog if path is not top
   var updog = ''
@@ -65,5 +78,45 @@ module.exports = async function renderDirectoryListingPage (archive, dirPath) {
   var summary = `<div class="entry">${totalFiles} ${pluralize(totalFiles, 'file')}</div>`
 
   // render final
-  return '<meta charset="UTF-8">' + styles + updog + entries + summary
+  return '<meta charset="UTF-8">' + styles + updog + entries + summary + '\n'
+}
+
+async function renderDirectoryListingPageJson (archive, dirPath) {
+  var entries = await getEntries(archive, dirPath)
+
+  var list = []
+
+  // render entries
+  entries.forEach(entry => {
+    var path = entry.path
+    var type = entry.isDirectory() ? 'directory' : 'file'
+    if (type === 'directory') path += '/'
+    let item = {
+      path,
+      name: entry.name,
+      type,
+      mtime: entry.mtime.getTime()
+    }
+    if (type === 'file') {
+      item.size = entry.size
+      item.blocks = entry.blocks
+      item.downloaded = entry.downloaded
+    }
+    list.push(item)
+  })
+  return JSON.stringify(list, null, 2) + '\n'
+}
+
+async function renderDirectoryListingPageText (archive, dirPath) {
+  var entries = await getEntries(archive, dirPath)
+
+  var text = ''
+
+  // render entries
+  entries.forEach(entry => {
+    var name = entry.name
+    if (entry.isDirectory()) name += '/'
+    text += name + '\n'
+  })
+  return text
 }


### PR DESCRIPTION
This PR implements #71 

The only behavioral changes are:

If no `Accept` header is sent by the client, it will render as JSON text (before it always rendered html)
If you do specify a format and it's on of the 3 supported formats, you'll get that format.
I added a newline to the end of the html format to make it CLI friendly.

The `text/plain` format is simply the filenames with a trailing slash on folders to signify it's a folder.

For example:

```http
imac:hashbase tim$ curl -i http://localhost:8080/ -H 'Host: fritter-admin.imac.local' -H 'Accept: text/plain'
HTTP/1.1 200 OK
X-Powered-By: Express
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 99
Content-Type: text/plain
Date: Mon, 08 Jan 2018 20:58:34 GMT
Connection: keep-alive
Transfer-Encoding: chunked

posts/
votes/
avatar.png
dat.json
profile.json
```

The `applicaiton/json` format is pretty close to the stat entries returned by hyperdrive, but only includes the interesting bits as well as the full path with trailing slash for directories:

```http
imac:hashbase tim$ curl -i http://localhost:8080/ -H 'Host: fritter-admin.imac.local' -H 'Accept: application/json'
HTTP/1.1 200 OK
X-Powered-By: Express
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 99
Content-Type: application/json
Date: Mon, 08 Jan 2018 20:59:34 GMT
Connection: keep-alive
Transfer-Encoding: chunked

[
  {
    "path": "/posts/",
    "name": "posts",
    "type": "directory",
    "mtime": 1515184134107
  },
  {
    "path": "/votes/",
    "name": "votes",
    "type": "directory",
    "mtime": 1515184134108
  },
  {
    "path": "/avatar.png",
    "name": "avatar.png",
    "type": "file",
    "mtime": 1515184134000,
    "size": 150859,
    "blocks": 3,
    "downloaded": 3
  },
  {
    "path": "/dat.json",
    "name": "dat.json",
    "type": "file",
    "mtime": 1515184133681,
    "size": 187,
    "blocks": 1,
    "downloaded": 1
  },
  {
    "path": "/profile.json",
    "name": "profile.json",
    "type": "file",
    "mtime": 1515433706000,
    "size": 1700,
    "blocks": 1,
    "downloaded": 1
  }
]
```
  