### PR TITLE
Sturdier approveDomains logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,42 +326,45 @@ function addConfigHelpers (config) {
 }
 
 function approveDomains (config, cloud) {
+  var domainReg
+  // Dots in domains are normal but dots in a regexp would be replaced with "any character"
+  var regHost = config.hostName.replace(/\./g, '\\.')
+  if (config.sites === 'per-archive') {
+    domainReg = new RegExp(`^(([^-]+)\-([^.]+)\\.)?${regHost}$`, 'g')
+  } else if (config.sites === 'per-user') {
+    domainReg = new RegExp(`^(()([^.]+)\\.)?${regHost}$`, 'g')
+  } else {
+    domainReg = new RegExp(`^${regHost}$`, 'g')
+  }
   return async (options, certs, cb) => {
     var {domain} = options
     options.agreeTos = true
     options.email = config.letsencrypt.email
 
-    // toplevel domain?
-    if (domain === config.hostname) {
-      return cb(null, {options, certs})
+    var domainParts = domainReg.exec(domain)
+    if (!domainParts) {
+      return cb(new Error('invalid domain'))
     }
-
-    // try looking up the site
+    var archiveName = domainParts[2]
+    var userName = domainParts[3]
+    
     try {
-      var archiveName
-      var userName
-      var domainParts = domain.split('.')
-      if (config.sites === 'per-user') {
-        // make sure the user record exists
-        userName = domainParts[0]
-        await cloud.usersDB.getByUsername(userName)
-        return cb(null, {options, certs})
-      } else if (config.sites === 'per-archive') {
-        // make sure the user and archive records exists
-        if (domainParts.length === 3) {
-          userName = archiveName = domainParts[0]
-        } else {
-          archiveName = domainParts[0]
-          userName = domainParts[1]
+      if (userName) {
+        var userRecord = await cloud.usersDB.getByUsername(userName)
+        if (!userRecord) {
+          return cb(new Error(`${userName} is not a user`))
         }
-        let userRecord = await cloud.usersDB.getByUsername(userName)
-        let archiveRecord = userRecord.archives.find(a => a.name === archiveName)
-        if (archiveRecord) {
-          return cb(null, {options, certs})
+        if (archiveName) {
+          var archiveRecord = userRecord.archives.find(a => a.name === archiveName)
+          if (!archiveRecord) {
+            return cb(new Error(`Archive ${archiveName} for user ${userName} not found!`))
+          }
         }
       }
-    } catch (e) {}
-    cb(new Error('Invalid domain'))
+    } catch (e) {
+      return cb(e)
+    }
+    cb(null, {options, certs})
   }
 }
 


### PR DESCRIPTION
This PR is making approveDomains sturdier for following cases:
- Former logic didn't work if `config.hostname` was a subdomain (or a sub-subdomain). example: `service.mydomain.com`
- Former logic used a `<archive>.<user>.<hostname*` in `per-archive` mode, instead of the correct `<archive>-<user>.<hostname>`.
- Former logic accepted all subdomains in `per-user` mode, no matter if the user existed or not. (`userRecord` can be `null`)
- Former logic was written in `return-first-on-success` code logic order. This is written in `return-first-on-error` making it easier to read.

I would love to get some guidance/mentoring on where to write proper tests for this. Also: it seems like there should be some central logic that maps domains to `domain-render-object`. I.e. `app.getDomainContext(domain)` to return either the "main" domain context or the context for user/archive.