### PR TITLE
Added pm2 config

### DIFF
--- a/pm2.config.js
+++ b/pm2.config.js
@@ -1,0 +1,20 @@
+'use strict'
+const {hostname} = require('os')
+const env = 'production'
+process.env.NODE_ENV = env
+const config = require('./lib/config')
+
+module.exports = {
+  apps: [{
+    script: './bin.js',
+    name: 'hashbase',
+    combine_logs: false,
+    pid_file: `${config.dir}/hashbase.pid`,
+    out_file: `${config.dir}/logs/hashbase_${hostname()}_out.log`,
+    err_file: `${config.dir}/logs/hashbase_${hostname()}_err.log`,
+    max_memory_restart: '2G',
+    env: {
+      NODE_ENV: env
+    }
+  }]
+}


### PR DESCRIPTION
I use `pm2` to run hashbase and found it quite useful, though there are a few settings that I found to be more useful in a `pm2.config.json` like log settings and pid. This PR adds said config for other people to use it too.