### PR TITLE
Stop showing pricing or upgrade plan when stripe is disabled.

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -53,9 +53,11 @@
           sure your content is always available.
         </p>
 
+        <% if (stripePK) { %>
         <p>
           <a href="/pricing">Get started</a>
         </p>
+        <% } %>
       </div>
 
       <div class="section features">

--- a/assets/html/account.html
+++ b/assets/html/account.html
@@ -21,7 +21,9 @@
       <nav class="subnav">
         <a href="#storage">Storage</a>
         <a href="#settings">Settings</a>
+        <% if (stripePK) { %>
         <a href="#plan">Plan</a>
+        <% } %>
       </nav>
 
       <div class="section usage">
@@ -87,6 +89,8 @@
         </div>
       </div>
 
+      <% if (stripePK) { %>
+
       <div class="section plan">
         <h2 id="plan">Plan</h2>
 
@@ -137,11 +141,13 @@
         <% } %>
 
       </div>
+      <% } %>
     </div>
     </main>
 
     <% include com/footer.html %>
     <% include com/stdjs.html %>
+    <% if (stripePK) { %>
     <script src="https://js.stripe.com/v3/"></script>
     <script>
       window.params = {
@@ -149,6 +155,7 @@
       }
     </script>
     <script src="/assets/js/account.js"></script>
+    <% } %>
 
   </body>
 </html>

--- a/assets/html/com/footer-light.html
+++ b/assets/html/com/footer-light.html
@@ -19,7 +19,9 @@
         <h2>Links</h2>
         <ul>
           <li><a href="/about">About</a></li>
+          <% if (stripePK) { %>
           <li><a href="/pricing">Pricing</a></li>
+          <% } %>
           <li><a href="/terms">Terms</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/support">Support</a></li>

--- a/assets/html/com/footer.html
+++ b/assets/html/com/footer.html
@@ -15,7 +15,9 @@
         <h2>Links</h2>
         <ul>
           <li><a href="/about">About</a></li>
+          <% if (stripePK) { %>
           <li><a href="/pricing">Pricing</a></li>
+          <% } %>
           <li><a href="/terms">Terms</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/support">Support</a></li>

--- a/assets/html/com/full-nav.html
+++ b/assets/html/com/full-nav.html
@@ -21,7 +21,7 @@
               <% } %>
               <a class="dropdown-item" href="/profile">View profile</a>
               <a class="dropdown-item" href="/account">Manage account</a>
-              <% if (sessionUser.plan === 'basic') { %>
+              <% if (stripePK && sessionUser.plan === 'basic') { %>
                 <a class="dropdown-item" href="/account/upgrade">
                   <span>Upgrade to pro</span>
                   <span class="pro-tag">pro</span>

--- a/assets/html/com/mobile-nav.html
+++ b/assets/html/com/mobile-nav.html
@@ -23,7 +23,7 @@
       <li class="nav-item">
         <a href="/account">Manage account</a>
       </li>
-      <% if (sessionUser.plan === 'basic') { %>
+      <% if (sessionUser.plan === 'basic' && stripePK) { %>
         <li class="nav-item">
           <a href="/account/upgrade">
             Upgrade to pro

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ module.exports = function (config) {
     session: false, // default session value
     sessionUser: false,
     errors: false, // common default value
+    // Using the stripe publishable key to identify whether or not to show pricing related information
+    // on any page
+    stripePK: config.stripe ? config.stripe.publishableKey : null,
     appInfo: {
       version: cloud.version,
       brandname: config.brandname,
@@ -122,7 +125,7 @@ module.exports = function (config) {
   app.use(analytics.middleware(cloud))
 
   // Create separater router for API
-  const api = createApiRouter(cloud)
+  const api = createApiRouter(cloud, config)
 
   // Use api routes before applying csurf middleware
   app.use('/v1', api)
@@ -152,13 +155,17 @@ module.exports = function (config) {
   app.get('/forgot-password', cloud.api.pages.forgotPassword)
   app.get('/reset-password', cloud.api.pages.resetPassword)
   app.get('/register', cloud.api.pages.register)
-  app.get('/register/pro', cloud.api.pages.registerPro)
+  if (config.stripe) {
+    app.get('/register/pro', cloud.api.pages.registerPro)
+  }
   app.get('/registered', cloud.api.pages.registered)
   app.get('/profile', cloud.api.pages.profileRedirect)
-  app.get('/account/upgrade', cloud.api.pages.accountUpgrade)
-  app.get('/account/upgraded', cloud.api.pages.accountUpgraded)
-  app.get('/account/cancel-plan', cloud.api.pages.accountCancelPlan)
-  app.get('/account/canceled-plan', cloud.api.pages.accountCanceledPlan)
+  if (config.stripe) {
+    app.get('/account/upgrade', cloud.api.pages.accountUpgrade)
+    app.get('/account/upgraded', cloud.api.pages.accountUpgraded)
+    app.get('/account/cancel-plan', cloud.api.pages.accountCancelPlan)
+    app.get('/account/canceled-plan', cloud.api.pages.accountCanceledPlan) 
+  }
   app.get('/account/change-password', cloud.api.pages.accountChangePassword)
   app.get('/account/update-email', cloud.api.pages.accountUpdateEmail)
   app.get('/account', cloud.api.pages.account)
@@ -248,7 +255,7 @@ module.exports = function (config) {
 
   return app
 }
-function createApiRouter (cloud) {
+function createApiRouter (cloud, config) {
   const router = new express.Router()
 
   // user & auth apis
@@ -260,10 +267,12 @@ function createApiRouter (cloud) {
   router.post('/account', cloud.api.users.updateAccount)
   router.post('/account/password', cloud.api.users.updateAccountPassword)
   router.post('/account/email', cloud.api.users.updateAccountEmail)
-  router.post('/account/upgrade', cloud.api.users.upgradePlan)
-  router.post('/account/register/pro', cloud.api.users.registerPro)
-  router.post('/account/update-card', cloud.api.users.updateCard)
-  router.post('/account/cancel-plan', cloud.api.users.cancelPlan)
+  if (config.stripe) {
+    router.post('/account/upgrade', cloud.api.users.upgradePlan)
+    router.post('/account/register/pro', cloud.api.users.registerPro)
+    router.post('/account/update-card', cloud.api.users.updateCard)
+    router.post('/account/cancel-plan', cloud.api.users.cancelPlan)
+  }
   router.post('/login', cloud.api.users.doLogin)
   router.get('/logout', cloud.api.users.doLogout)
   router.post('/forgot-password', cloud.api.users.doForgotPassword)

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports = function (config) {
     app.get('/account/upgrade', cloud.api.pages.accountUpgrade)
     app.get('/account/upgraded', cloud.api.pages.accountUpgraded)
     app.get('/account/cancel-plan', cloud.api.pages.accountCancelPlan)
-    app.get('/account/canceled-plan', cloud.api.pages.accountCanceledPlan) 
+    app.get('/account/canceled-plan', cloud.api.pages.accountCanceledPlan)
   }
   app.get('/account/change-password', cloud.api.pages.accountChangePassword)
   app.get('/account/update-email', cloud.api.pages.accountUpdateEmail)

--- a/lib/apis/pages.js
+++ b/lib/apis/pages.js
@@ -174,7 +174,6 @@ class PagesAPI {
     res.render('register-pro', {
       id: req.query.id,
       email: req.query.email,
-      stripePK: this.config.stripe ? this.config.stripe.publishableKey : null,
       salesTax: this.config.stripe ? this.config.stripe.salesTaxPct : null,
       csrfToken: req.csrfToken()
     })
@@ -201,7 +200,6 @@ class PagesAPI {
     var diskQuota = sessionUser ? this.config.getUserDiskQuota(sessionUser) : undefined
 
     res.render('account', {
-      stripePK: this.config.stripe ? this.config.stripe.publishableKey : null,
       updated: req.query.updated,
       ucfirst,
       pluralize,
@@ -217,7 +215,6 @@ class PagesAPI {
     var {session} = res.locals
     if (!session) return res.redirect('/login?redirect=account/upgrade')
     res.render('account-upgrade', {
-      stripePK: this.config.stripe ? this.config.stripe.publishableKey : null,
       salesTax: this.config.stripe ? this.config.stripe.salesTaxPct : null,
       csrfToken: req.csrfToken()
     })


### PR DESCRIPTION
It is possible to disable stripe in the configuration, then though the settings for the plan is still available. This PR hides removes related endpoints and parts of the UI that related to it if stripe is disabled.