### PR TITLE
Change archive addressing to no longer require the username postfix

### DIFF
--- a/assets/html/new-archive.html
+++ b/assets/html/new-archive.html
@@ -38,7 +38,7 @@
             <p class="form-group">
               <label for="add-archive-name-input">Name</label>
               <input required type="text" class="form-control" id="add-archive-name-input"
-              placeholder="Untitled" name="name">
+              placeholder="Optional" name="name">
               <span id="add-archive-name-error" class="form-control-feedback"></span>
               <p id="add-archive-name-output-container">
                 Your archive's URL:

--- a/assets/html/new-archive.html
+++ b/assets/html/new-archive.html
@@ -43,7 +43,7 @@
               <p id="add-archive-name-output-container">
                 Your archive's URL:
                 <code>
-                  <span id="add-archive-name-output">-</span><%= sessionUser.username %>.<%= appInfo.hostname %>
+                  <span id="add-archive-name-output"></span>.<%= appInfo.hostname %>
                 </code></p>
             </p>
 

--- a/assets/js/new-archive.js
+++ b/assets/js/new-archive.js
@@ -72,7 +72,7 @@ $(function () {
     if (nameVal === window.params.username) {
       addArchiveNameOutput.text('')
     } else {
-      addArchiveNameOutput.text((nameVal || '') + '-')
+      addArchiveNameOutput.text(nameVal || '')
     }
 
     // update submit button disabled state

--- a/bin.js
+++ b/bin.js
@@ -4,19 +4,22 @@ var createApp = require('./index')
 var log = require('debug')('LE')
 var figures = require('figures')
 
-var app = createApp(config)
-if (config.letsencrypt) {
-  var greenlockExpress = require('greenlock-express')
-  var debug = config.letsencrypt.debug !== false
-  greenlockExpress.create({
-    server: debug ? 'staging' : 'https://acme-v01.api.letsencrypt.org/directory',
-    debug,
-    approveDomains: app.approveDomains,
-    app,
-    log
-  }).listen(80, 443)
-} else {
-  app.listen(config.port, () => {
-    console.log(figures.tick, `Server started on http://127.0.0.1:${config.port}`)
-  })
+async function start () {
+  var app = await createApp(config)
+  if (config.letsencrypt) {
+    var greenlockExpress = require('greenlock-express')
+    var debug = config.letsencrypt.debug !== false
+    greenlockExpress.create({
+      server: debug ? 'staging' : 'https://acme-v01.api.letsencrypt.org/directory',
+      debug,
+      approveDomains: app.approveDomains,
+      app,
+      log
+    }).listen(80, 443)
+  } else {
+    app.listen(config.port, () => {
+      console.log(figures.tick, `Server started on http://127.0.0.1:${config.port}`)
+    })
+  }
 }
+start()

--- a/config.defaults.yml
+++ b/config.defaults.yml
@@ -8,6 +8,7 @@ sites: false
 rateLimiting: true
 csrf: true
 defaultDiskUsageLimit: 100mb
+defaultNamedArchivesLimit: 25
 
 # processing jobs
 jobs:

--- a/index.js
+++ b/index.js
@@ -17,12 +17,14 @@ const customSanitizers = require('./lib/sanitizers')
 const analytics = require('./lib/analytics')
 const packageJson = require('./package.json')
 
-module.exports = function (config) {
+module.exports = async function (config) {
   console.log(figures.heart, 'Hello friend')
   console.log(figures.pointerSmall, 'Instantiating backend')
   addConfigHelpers(config)
   var cloud = new Hypercloud(config)
   cloud.version = packageJson.version
+  await cloud.setupDatabase() // pause all loading during DB setup
+  cloud.loadAllArchives()
   cloud.setupAdminUser()
 
   console.log(figures.pointerSmall, 'Instantiating server')

--- a/index.js
+++ b/index.js
@@ -439,14 +439,8 @@ function approveDomains (config, cloud) {
         return cb(null, {options, certs})
       } else if (config.sites === 'per-archive') {
         // make sure the user and archive records exists
-        if (domainParts.length === 3) {
-          userName = archiveName = domainParts[0]
-        } else {
-          archiveName = domainParts[0]
-          userName = domainParts[1]
-        }
-        let userRecord = await cloud.usersDB.getByUsername(userName)
-        let archiveRecord = userRecord.archives.find(a => a.name === archiveName)
+        archiveName = domainParts[0]
+        let archiveRecord = await cloud.archivesDB.getByName(archiveName)
         if (archiveRecord) {
           return cb(null, {options, certs})
         }

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -97,6 +97,7 @@ module.exports = class AdminAPI {
       .isLength({ min: 3, max: 16 }).withMessage('Must be 3 to 16 characters.')
     req.checkBody('email', 'Must be a valid email').optional()
       .isEmail()
+      .isSimpleEmail()
       .isLength({ min: 3, max: 100 })
     req.checkBody('scopes', 'Must be an array of strings.').optional()
       .isScopesArray()

--- a/lib/apis/admin.js
+++ b/lib/apis/admin.js
@@ -191,11 +191,11 @@ module.exports = class AdminAPI {
     var archives
     if (req.query.view === 'dashboard') {
       // pull down all records, the client is going to handle everything
-      archives = await this.archivesDB.list({getExtra: true})
+      archives = await this.archivesDB.list()
       archives = archives.map(archive => ({
         key: archive.key,
         name: archive.name,
-        owner: archive.owner ? archive.owner.username : null,
+        owner: archive.ownerName,
         diskUsage: archive.numBlocks ? bytes.format(archive.numDownloadedBlocks / archive.numBlocks * archive.numBytes) : 0,
         totalSize: bytes.format(archive.numBytes),
         createdAt: archive.createdAt

--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -21,22 +21,11 @@ module.exports = class ArchiveFilesAPI {
     const findFn = test => a => a.name.toLowerCase() === test
 
     if (this.config.sites === 'per-archive') {
-      let vhostParts = req.vhost[0].split('-')
-      if (vhostParts.length === 1) {
-        // user.domain
-        username = archname = vhostParts[0]
-      } else {
-        // archive-user.domain
-        archname = vhostParts.slice(0, -1).join('-')
-        username = vhostParts[vhostParts.length - 1]
-      }
-
-      // lookup user record
-      userRecord = await this.usersDB.getByUsername(username)
-      if (!userRecord) throw new NotFoundError()
+      // archive.domain
+      let archname = req.vhost[0]
 
       // lookup archive record
-      archiveRecord = userRecord.archives.find(findFn(archname))
+      archiveRecord = this.archivesDB.getByName(archname)
       if (!archiveRecord) throw new NotFoundError()
       return archiveRecord
     } else {

--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -52,6 +52,17 @@ module.exports = class ArchivesAPI {
       // fetch user's record
       var userRecord = await this.usersDB.getByID(res.locals.session.id)
 
+      // enforce names limit
+      if (name && typeof this.config.defaultNamedArchivesLimit === 'number') {
+        var numNamedArchives = userRecord.archives.filter(a => !!a.name).length
+        if (numNamedArchives >= this.config.defaultNamedArchivesLimit) {
+          return res.status(422).json({
+            message: `You can only use ${this.config.defaultNamedArchivesLimit} names. You must upload this archive without a name.`,
+            outOfNamedArchives: true
+          })
+        }
+      }
+
       // check that the user has the available quota
       if (this.config.getUserDiskQuotaPct(userRecord) >= 1) {
         return res.status(422).json({
@@ -275,6 +286,19 @@ module.exports = class ArchivesAPI {
               }
             }
           })
+        }
+      }
+
+      // enforce names limit
+      if (name && !archiveRecord.name /* only need to check if giving a name to an archive that didnt have one */) {
+        if (typeof this.config.defaultNamedArchivesLimit === 'number') {
+          var numNamedArchives = userRecord.archives.filter(a => !!a.name).length
+          if (numNamedArchives >= this.config.defaultNamedArchivesLimit) {
+            return res.status(422).json({
+              message: `You can only use ${this.config.defaultNamedArchivesLimit} names. You must upload this archive without a name.`,
+              outOfNamedArchives: true
+            })
+          }
         }
       }
 

--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -60,24 +60,34 @@ module.exports = class ArchivesAPI {
         })
       }
 
-      if (name && userRecord.archives.find(a => a.name === name)) {
-        return res.status(422).json({
-          message: `You already have an archive named ${name}. Please select a new name.`
-        })
+      // check that the name isnt taken
+      if (name) {
+        let existingArchive = await this.archivesDB.getByName(name)
+        if (existingArchive && key !== existingArchive.key) {
+          return res.status(422).json({
+            message: `${name} has already been taken. Please select a new name.`
+          })
+        }
       }
 
       // update the records
-      // TEMPORARY we have to do addHostingUser first, and cancel if that fails
+      // TEMPORARY we have to do addHostingUser first, and cancel if that fails -prf
       // await Promise.all([
       //   this.usersDB.addArchive(userRecord.id, key, name),
       //   this.archivesDB.addHostingUser(key, userRecord.id)
       // ])
       try {
-        await this.archivesDB.addHostingUser(key, userRecord.id)
-      } catch (e) {
-        return res.status(422).json({
-          message: 'This archive is already being hosted by someone else'
+        await this.archivesDB.addHostingUser(key, userRecord.id, {
+          name,
+          ownerName: userRecord.username
         })
+      } catch (e) {
+        if (e.alreadyHosted) {
+          return res.status(422).json({
+            message: 'This archive is already being hosted by someone else'
+          })
+        }
+        throw e // internal error
       }
       await this.usersDB.addArchive(userRecord.id, key, name)
     } finally {
@@ -220,23 +230,27 @@ module.exports = class ArchivesAPI {
         throw new NotFoundError()
       }
 
-      // make sure the name is available
-      if (name && userRecord.archives.find(a => a.key !== key && a.name === name)) {
-        return res.status(422).json({
-          message: 'There were errors in your submission',
-          details: {
-            name: {
-              msg: `You already have an archive named ${name}. Please select a new name.`
+      // check that the name isnt taken
+      if (name) {
+        let existingArchive = await this.archivesDB.getByName(name)
+        if (existingArchive && existingArchive.key !== key) {
+          return res.status(422).json({
+            message: `${name} has already been taken. Please select a new name.`,
+            details: {
+              name: {
+                msg: `${name} has already been taken. Please select a new name.`
+              }
             }
-          }
-        })
+          })
+        }
       }
 
       // update the records
-      if (typeof name !== 'undefined') {
-        archiveRecord.name = name
-      }
-      // update records
+      archiveRecord.name = name
+      await this.archivesDB.addHostingUser(archiveRecord.key, userRecord.id, {
+        name,
+        ownerName: userRecord.username
+      })
       await this.usersDB.put(userRecord)
     } finally {
       release[0]()
@@ -312,9 +326,7 @@ module.exports = class ArchivesAPI {
     // figure out additional urls
     var additionalUrls = []
     if (archive.name) {
-      var niceUrl = archive.name === userRecord.username
-        ? `${userRecord.username}.${this.config.hostname}`
-        : `${archive.name}-${userRecord.username}.${this.config.hostname}`
+      var niceUrl = `${archive.name}.${this.config.hostname}`
       additionalUrls = [`dat://${niceUrl}`, `https://${niceUrl}`]
     }
 

--- a/lib/apis/archives.js
+++ b/lib/apis/archives.js
@@ -60,12 +60,31 @@ module.exports = class ArchivesAPI {
         })
       }
 
-      // check that the name isnt taken
       if (name) {
+        let isAvailable = true
+
+        // check that the name isnt reserved
+        var {reservedNames} = this.config.registration
+        if (reservedNames && Array.isArray(reservedNames) && reservedNames.length > 0) {
+          if (reservedNames.indexOf(name.toLowerCase()) !== -1) {
+            isAvailable = false
+          }
+        }
+
+        // check that the name isnt taken
         let existingArchive = await this.archivesDB.getByName(name)
-        if (existingArchive && key !== existingArchive.key) {
+        if (existingArchive && existingArchive.key !== key) {
+          isAvailable = false
+        }
+
+        if (!isAvailable) {
           return res.status(422).json({
-            message: `${name} has already been taken. Please select a new name.`
+            message: `${name} has already been taken. Please select a new name.`,
+            details: {
+              name: {
+                msg: `${name} has already been taken. Please select a new name.`
+              }
+            }
           })
         }
       }
@@ -230,10 +249,24 @@ module.exports = class ArchivesAPI {
         throw new NotFoundError()
       }
 
-      // check that the name isnt taken
       if (name) {
+        let isAvailable = true
+
+        // check that the name isnt reserved
+        var {reservedNames} = this.config.registration
+        if (reservedNames && Array.isArray(reservedNames) && reservedNames.length > 0) {
+          if (reservedNames.indexOf(name.toLowerCase()) !== -1) {
+            isAvailable = false
+          }
+        }
+
+        // check that the name isnt taken
         let existingArchive = await this.archivesDB.getByName(name)
         if (existingArchive && existingArchive.key !== key) {
+          isAvailable = false
+        }
+
+        if (!isAvailable) {
           return res.status(422).json({
             message: `${name} has already been taken. Please select a new name.`,
             details: {

--- a/lib/apis/user-content.js
+++ b/lib/apis/user-content.js
@@ -27,9 +27,7 @@ class UserContentAPI {
     var isOwner = session && session.id === userRecord.id
 
     // figure out url
-    var niceUrl = archivename === username
-      ? `${username}.${this.config.hostname}`
-      : `${archivename}-${username}.${this.config.hostname}`
+    var niceUrl = `${archivename}.${this.config.hostname}`
 
     // load progress
     var progress

--- a/lib/apis/users.js
+++ b/lib/apis/users.js
@@ -28,6 +28,7 @@ module.exports = class UsersAPI {
       .isLength({ min: 3, max: 16 }).withMessage('Must be 3 to 16 characters.')
     req.checkBody('email', 'Must be a valid email')
       .isEmail({ allow_utf8_local_part: false })
+      .isSimpleEmail()
       .isLength({ min: 3, max: 100 })
     req.checkBody('password', 'Must be 6 to 100 characters.').isLength({ min: 6, max: 100 })
     req.checkBody('passwordConfirm', 'Must be 6 to 100 characters').isLength({ min: 6, max: 100 })
@@ -613,7 +614,10 @@ module.exports = class UsersAPI {
 
   async doForgotPassword (req, res) {
     // validate & sanitize input
-    req.checkBody('email', 'Must be a valid email').isEmail().isLength({ min: 3, max: 100 })
+    req.checkBody('email', 'Must be a valid email')
+      .isEmail()
+      .isSimpleEmail()
+      .isLength({ min: 3, max: 100 })
     ;(await req.getValidationResult()).throw()
     var {email} = req.body
 

--- a/lib/apis/users.js
+++ b/lib/apis/users.js
@@ -58,7 +58,7 @@ module.exports = class UsersAPI {
     if (reservedNames && Array.isArray(reservedNames) && reservedNames.length > 0) {
       if (reservedNames.indexOf(username.toLowerCase()) !== -1) {
         let error = {
-          message: 'That username is reserved, please choose another.',
+          message: 'That username is not available, please choose another.',
           reservedName: true
         }
         return res.status(422).json(error)

--- a/lib/dbs/archives.js
+++ b/lib/dbs/archives.js
@@ -24,7 +24,7 @@ class ArchivesDB extends EventEmitter {
     this.indexDB = sublevel(cloud.db, 'archives-index')
     this.indexer = createIndexer(this.indexDB, {
       keyName: 'key',
-      properties: ['createdAt'],
+      properties: ['name', 'createdAt'],
       map: (key, next) => {
         this.getExtraByKey(key)
           .catch(next)
@@ -45,13 +45,15 @@ class ArchivesDB extends EventEmitter {
     assert(typeof record.key === 'string')
     record = Object.assign({}, ArchivesDB.defaults(), record)
     record.createdAt = Date.now()
-    await this.put(record)
-    await this.indexer.updateIndexes(record)
+    await this._put(record)
+    await this.indexer.addIndexes(record)
     this.emit('create', record)
     return record
   }
 
-  async put (record) {
+  // just use internally - this method is a bit of a footgun
+  // (it doesnt update indexes or use a transaction)
+  async _put (record) {
     assert(typeof record.key === 'string')
     record.updatedAt = Date.now()
     await this.archivesDB.put(record.key, record)
@@ -66,6 +68,7 @@ class ArchivesDB extends EventEmitter {
     var release = await lock('archives')
     try {
       var record = await this.getByKey(key)
+      await this.indexer.removeIndexes(record)
       for (var k in updates) {
         if (k === 'key' || typeof updates[k] === 'undefined') {
           continue // dont allow that!
@@ -74,7 +77,7 @@ class ArchivesDB extends EventEmitter {
       }
       record.updatedAt = Date.now()
       await this.archivesDB.put(record.key, record)
-      await this.indexer.updateIndexes(record)
+      await this.indexer.addIndexes(record)
     } finally {
       release()
     }
@@ -130,9 +133,7 @@ class ArchivesDB extends EventEmitter {
     if (record.hostingUsers[0]) {
       record.owner = await this.usersDB.getByID(record.hostingUsers[0])
       record.name = record.owner.archives.find(a => a.key === key).name
-      record.niceUrl = record.name === record.owner.username
-        ? `${record.owner.username}.${this.config.hostname}`
-        : `${record.name}-${record.owner.username}.${this.config.hostname}`
+      record.niceUrl = `${record.name}.${this.config.hostname}`
     } else {
       record.owner = null
       record.name = ''
@@ -143,6 +144,11 @@ class ArchivesDB extends EventEmitter {
     return record
   }
 
+  async getByName (name) {
+    assert(typeof name === 'string')
+    return this.indexer.findOne('name', name)
+  }
+
   list ({cursor, limit, reverse, sort, getExtra} = {}) {
     // 'popular' uses a special index
     if (sort === 'popular') {
@@ -151,7 +157,16 @@ class ArchivesDB extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       var opts = {limit, reverse}
-      if (typeof cursor !== 'undefined') {
+      // find indexes require a start- and end-point
+      if (sort === 'createdAt') {
+        if (reverse) {
+          opts.lt = cursor || '\xff'
+          opts.gte = 0
+        } else {
+          opts.gt = cursor || 0
+          opts.lte = '\xff'
+        }
+      } else if (typeof cursor !== 'undefined') {
         // set cursor according to reverse
         if (reverse) opts.lt = cursor
         else opts.gt = cursor
@@ -196,24 +211,35 @@ class ArchivesDB extends EventEmitter {
   // highlevel updates
   // =
 
-  async addHostingUser (key, userId) {
+  async addHostingUser (key, userId, denormalizedData = {}) {
     // fetch/create record
     var archiveRecord = await this.getOrCreateByKey(key)
 
-    // add user
-    if (archiveRecord.hostingUsers.includes(userId)) {
-      return // already hosting
-    }
+    // remove old indexes
+    await this.indexer.removeIndexes(archiveRecord)
 
-    // TEMPORARY
-    // only allow one hosting user per archive
-    if (archiveRecord.hostingUsers.length > 0) {
-      throw new Error('Cant add another user')
+    // include denormalized (non-authoritative) data
+    if (typeof denormalizedData.ownerName !== 'string') {
+      throw new Error('Must include denormalized data (ownerName)')
+    }
+    archiveRecord.name = denormalizedData.name
+    archiveRecord.ownerName = denormalizedData.ownerName
+
+    // add user
+    if (!archiveRecord.hostingUsers.includes(userId)) {
+      // TEMPORARY
+      // only allow one hosting user per archive
+      if (archiveRecord.hostingUsers.length > 0) {
+        let err = new Error('Cant add another user')
+        err.alreadyHosted = true
+        throw err
+      }
+      archiveRecord.hostingUsers.push(userId)
     }
 
     // update records
-    archiveRecord.hostingUsers.push(userId)
-    await this.put(archiveRecord)
+    await this._put(archiveRecord)
+    await this.indexer.addIndexes(archiveRecord)
     this.emit('add-hosting-user', {key, userId}, archiveRecord)
 
     // track dead archives
@@ -224,6 +250,9 @@ class ArchivesDB extends EventEmitter {
     // fetch/create record
     var archiveRecord = await this.getOrCreateByKey(key)
 
+    // remove old indexes
+    await this.indexer.removeIndexes(archiveRecord)
+
     // remove user
     var index = archiveRecord.hostingUsers.indexOf(userId)
     if (index === -1) {
@@ -232,7 +261,10 @@ class ArchivesDB extends EventEmitter {
     archiveRecord.hostingUsers.splice(index, 1)
 
     // update records
-    await this.put(archiveRecord)
+    await this._put(archiveRecord)
+    if (archiveRecord.hostingUsers.length > 0) {
+      await this.indexer.addIndexes(archiveRecord) // only readd indexes if there are hosting users
+    }
     this.emit('remove-hosting-user', {key, userId}, archiveRecord)
 
     // track dead archives
@@ -267,7 +299,11 @@ module.exports = ArchivesDB
 ArchivesDB.defaults = () => ({
   key: null,
 
-  hostingUsers: [],
+  hostingUsers: [], // NOTE currently just 1 entry is allowed
+
+  // denormalized data
+  name: false, // stored canonically in the hosting user record
+  ownerName: '', // stored canonically in the hosting user record
 
   // stats
   diskUsage: undefined,

--- a/lib/dbs/schemas.js
+++ b/lib/dbs/schemas.js
@@ -1,0 +1,123 @@
+const assert = require('assert')
+const figures = require('figures')
+const pump = require('pump')
+const through = require('through2')
+
+// constants
+// =
+
+const CURRENT_DB_VERSION = 2
+
+// exported api
+// =
+
+class Schemas {
+  constructor (cloud) {
+    this.cloud = cloud
+  }
+
+  // basic ops
+  // =
+
+  async getDBVersion () {
+    return new Promise((resolve, reject) => {
+      this.cloud.db.get('db-version', (err, v) => {
+        if (err && err.notFound) resolve(1) // default to 1
+        else if (!err) resolve(+v)
+        else reject(err)
+      })
+    })
+  }
+
+  async setDBVersion (v) {
+    assert(typeof v === 'number')
+    return new Promise((resolve, reject) => {
+      this.cloud.db.put('db-version', v, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+
+  // migrations
+  // =
+
+  async migrate () {
+    var v = await this.getDBVersion()
+    if (v >= CURRENT_DB_VERSION) {
+      console.log(figures.tick, 'Database loaded at version', v)
+      return
+    }
+
+    console.log(figures.pointerSmall, 'Running database migrations to bring version', v, 'to version', CURRENT_DB_VERSION)
+    for (v; v < CURRENT_DB_VERSION; v++) {
+      console.log(figures.pointerSmall, `v${v} migration started...`)
+      await this[`to${v + 1}`]()
+    }
+    await this.setDBVersion(CURRENT_DB_VERSION)
+    console.log(figures.tick, 'Database updated to version', v)
+  }
+
+  async to2 () {
+    /**
+    In V2, we had two changes around how archives work:
+
+      1. Archive subdomains are no longer post-fixed by the username.
+         An archive with the name 'foo' will be at 'foo.hashbase.io', not 'foo-bob.hashbase.io'.
+      2. Archive records now record some "denormalized" data for performance.
+         That data is their name, and their owner's name.
+
+    At time of migration, we need to populate all of the denormalization fields, but also --
+
+    #1 is a change to user-facing policy. To make the transition smooth, we rename all archives so
+    that the new policy has no immediate effect. The previous policy was that an archive was hosted
+    at 'archivename-username.hashbase.io' unless 'archivename' === 'username', in which case it was
+    hosted at 'username.hashbase.io'. This leads us to the following rules:
+
+      - If 'archivename' !== 'username', then 'archivename' = `${archivename}-${username}`
+      - Else, then 'archivename' = 'archivename'
+
+    **/
+    return new Promise((resolve, reject) => {
+      pump(
+        // stream the users
+        this.cloud.usersDB.accountsDB.createValueStream(),
+        through.obj(async (userRecord, enc, cb) => {
+          // sanity check
+          if (!userRecord || !userRecord.archives || !Array.isArray(userRecord.archives)) {
+            console.log('skipping bad user record', userRecord)
+            return cb() // skip it
+          }
+
+          // iterate their archives
+          for (let archive of userRecord.archives) {
+            // update the name
+            if (!archive.name || archive.name === userRecord.username) {
+              // do nothing
+            } else {
+              // rename
+              let oldName = archive.name
+              archive.name = `${archive.name}-${userRecord.username}`
+              console.log('setting', oldName, 'to', archive.name)
+            }
+
+            // update the archive record
+            await this.cloud.archivesDB.update(archive.key, {
+              name: archive.name,
+              ownerName: userRecord.username
+            })
+          }
+
+          // update the user record
+          await this.cloud.usersDB.update(userRecord.id, userRecord)
+          cb()
+        }),
+        (err) => {
+          if (err) reject(err)
+          else resolve()
+        }
+      )
+    })
+  }
+}
+module.exports = Schemas

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ const ServiceAPI = require('./apis/service')
 const UserContentAPI = require('./apis/user-content')
 const PagesAPI = require('./apis/pages')
 const AdminAPI = require('./apis/admin')
+const Shemas = require('./dbs/schemas')
 const UsersDB = require('./dbs/users')
 const ArchivesDB = require('./dbs/archives')
 const ActivityDB = require('./dbs/activity')
@@ -98,7 +99,15 @@ class Hypercloud {
     wrapAll(this.api.pages)
     wrapAll(this.api.admin)
     wrapAll(this.api.reports)
+  }
 
+  async setupDatabase () {
+    // run db migrations
+    var schemas = new Shemas(this)
+    await schemas.migrate()
+  }
+
+  async loadAllArchives () {
     // load all archives
     var ps = []
     this.archivesDB.archivesDB.createKeyStream().on('data', key => {

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -22,7 +22,7 @@ exports.isScopesArray = value => {
 }
 
 exports.isSimpleEmail = value => {
-  return typeof value === 'string'
+  return typeof value === 'string' && value.indexOf('+') === -1
 }
 
 exports.isPassword = value => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install-transpiler": "npm install babel-preset-es2015",
     "start": "node bin.js",
     "test": "npm run unit && npm run lint",
-    "unit": "ava test/*.js",
+    "unit": "ava test/*.js --fail-fast",
     "lint": "standard"
   },
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ port: 8080                    # the port to run the service on
 rateLimiting: true            # rate limit the HTTP requests?
 csrf: true                    # use csrf tokens?
 defaultDiskUsageLimit: 100mb  # default maximum disk usage for each user
+defaultNamedArchivesLimit: 25 # how many names can a user take?
 ```
 
 #### Lets Encrypt
@@ -59,23 +60,13 @@ admin:
 
 #### HTTP Sites
 
-Hashbase can host the archives as HTTP sites. This has the added benefit of enabling [dat-dns shortnames](https://npm.im/dat-dns) for the archives. There are two possible schemes:
-
-```yaml
-sites: per-user
-```
-
-Per-user will host archives at `username.hostname/archivename`, in a scheme similar to GitHub Pages. If the archive-name is == to the username, it will be hosted at `username.hostname`.
-
-Note that, in this scheme, a DNS shortname is only provided for the user archive (`username.hostname`).
+Hashbase can host the archives as HTTP sites. This has the added benefit of enabling [dat-dns shortnames](https://npm.im/dat-dns) for the archives.
 
 ```yaml
 sites: per-archive
 ```
 
-Per-archive will host archives at `archivename-username.hostname`. If the archive-name is == to the username, it will be hosted at `username.hostname`.
-
-By default, HTTP Sites are disabled.
+This will host archives at `archivename.hostname`. By default, HTTP Sites are disabled.
 
 #### Closed Registration
 

--- a/test/activity.js
+++ b/test/activity.js
@@ -7,8 +7,9 @@ var fakeDatKey1 = 'a'.repeat(64)
 var fakeDatKey2 = 'b'.repeat(64)
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     // login
     var res = await app.req.post({

--- a/test/admin.js
+++ b/test/admin.js
@@ -8,8 +8,9 @@ var app
 var sessionToken, auth, testDatKey
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     // login
     var res = await app.req.post({

--- a/test/archives.js
+++ b/test/archives.js
@@ -11,8 +11,9 @@ var testDat, testDatKey
 var fsstat = promisify(fs.stat, fs)
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     // login
     var res = await app.req.post({
@@ -261,7 +262,7 @@ test('change archive name', async t => {
     name: 'test-archive',
     title: 'Test Dat 1',
     description: 'The first test dat',
-    additionalUrls: ['dat://test-archive-admin.test.local', 'https://test-archive-admin.test.local']
+    additionalUrls: ['dat://test-archive.test.local', 'https://test-archive.test.local']
   })
 
   res = await app.req.get({url: '/v2/archives', json: true, auth})
@@ -271,7 +272,7 @@ test('change archive name', async t => {
     name: 'test-archive',
     title: 'Test Dat 1',
     description: 'The first test dat',
-    additionalUrls: ['dat://test-archive-admin.test.local', 'https://test-archive-admin.test.local']
+    additionalUrls: ['dat://test-archive.test.local', 'https://test-archive.test.local']
   })
 
   // change to invalid names
@@ -317,15 +318,38 @@ test('change archive name', async t => {
   t.is(res.statusCode, 404, '404 old name not found')
 })
 
-test('dont allow two archives with same name for given user', async t => {
+test('dont allow two archives with same name', async t => {
+  var key = 'b'.repeat(64)
+  var key2 = 'c'.repeat(64)
+
   // add archive
-  var json = {key: testDatKey, name: 'test-duplicate-archive'}
+  var json = {key, name: 'test-duplicate-archive'}
   var res = await app.req.post({uri: '/v2/archives/add', json, auth})
   t.is(res.statusCode, 200, '200 added dat')
 
   // add the archive again
   res = await app.req.post({uri: '/v2/archives/add', json, auth})
+  t.is(res.statusCode, 200, '200 no change')
+
+  // add as a different user
+  json = {key: key2, name: 'test-duplicate-archive'}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
   t.is(res.statusCode, 422, '422 name already in use')
+
+  // rename to self (no change)
+  json = {name: 'test-duplicate-archive'}
+  res = await app.req.post({uri: '/v2/archives/item/' + key, json, auth})
+  t.is(res.statusCode, 200, '200 can rename to self')
+
+  // rename to existing (fail)
+  json = {name: 'test--dat'}
+  res = await app.req.post({uri: '/v2/archives/item/' + key, json, auth})
+  t.is(res.statusCode, 422, '422 name already in use')
+
+  // remove the archive
+  json = {key}
+  res = await app.req.post({uri: '/v2/archives/remove', json, auth})
+  t.is(res.statusCode, 200, '200 removed')
 })
 
 test.cb('archive is accessable via dat swarm', t => {

--- a/test/archives.js
+++ b/test/archives.js
@@ -327,11 +327,16 @@ test('dont allow two archives with same name', async t => {
   var res = await app.req.post({uri: '/v2/archives/add', json, auth})
   t.is(res.statusCode, 200, '200 added dat')
 
-  // add the archive again
+  // add the archive again (no change)
   res = await app.req.post({uri: '/v2/archives/add', json, auth})
   t.is(res.statusCode, 200, '200 no change')
 
-  // add as a different user
+  // add a reserved name (fail)
+  json = {key, name: 'reserved'}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth})
+  t.is(res.statusCode, 422, '422 name already in use')
+
+  // add as a different user (fail)
   json = {key: key2, name: 'test-duplicate-archive'}
   res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
   t.is(res.statusCode, 422, '422 name already in use')
@@ -343,6 +348,11 @@ test('dont allow two archives with same name', async t => {
 
   // rename to existing (fail)
   json = {name: 'test--dat'}
+  res = await app.req.post({uri: '/v2/archives/item/' + key, json, auth})
+  t.is(res.statusCode, 422, '422 name already in use')
+
+  // rename to reserved (no change)
+  json = {name: 'reserved'}
   res = await app.req.post({uri: '/v2/archives/item/' + key, json, auth})
   t.is(res.statusCode, 422, '422 name already in use')
 

--- a/test/dat-pinning-client.js
+++ b/test/dat-pinning-client.js
@@ -5,8 +5,9 @@ const createTestServer = require('./lib/server.js')
 var app
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     t.pass('started')
     t.end()
@@ -75,8 +76,8 @@ test.cb('add & remove dats', t => {
           title: '',
           description: '',
           additionalUrls: [
-            'dat://mysite-admin.test.local',
-            'https://mysite-admin.test.local'
+            'dat://mysite.test.local',
+            'https://mysite.test.local'
           ]
         })
 
@@ -95,8 +96,8 @@ test.cb('add & remove dats', t => {
               title: '',
               description: '',
               additionalUrls: [
-                'dat://my-site-admin.test.local',
-                'https://my-site-admin.test.local'
+                'dat://my-site.test.local',
+                'https://my-site.test.local'
               ]
             })
 
@@ -110,8 +111,8 @@ test.cb('add & remove dats', t => {
                   title: '',
                   description: '',
                   additionalUrls: [
-                    'dat://my-site-admin.test.local',
-                    'https://my-site-admin.test.local'
+                    'dat://my-site.test.local',
+                    'https://my-site.test.local'
                   ]
                 }
               ])

--- a/test/featured-archives.js
+++ b/test/featured-archives.js
@@ -8,8 +8,9 @@ var sessionToken, auth
 var testDatKey
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     // login
     var res = await app.req.post({

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -34,6 +34,7 @@ async function createLocalApp (cb) {
     dir: tmpdir,
     port: portCounter++,
     defaultDiskUsageLimit: '100mb',
+    defaultNamedArchivesLimit: 3,
     pm2: false,
     admin: {
       password: 'foobar'

--- a/test/lib/server.js
+++ b/test/lib/server.js
@@ -21,11 +21,10 @@ function createRemoteApp (cb) {
     req: request.defaults({ baseUrl: url, timeout: 10e3, resolveWithFullResponse: true, simple: false }),
     close: cb => cb()
   }
-  cb()
-  return app
+  cb(null, app)
 }
 
-function createLocalApp (cb) {
+async function createLocalApp (cb) {
   // setup config
   // =
 
@@ -75,10 +74,10 @@ function createLocalApp (cb) {
   // create server
   // =
 
-  var app = createApp(config)
+  var app = await createApp(config)
   var server = app.listen(config.port, (err) => {
     console.log(`server started on http://127.0.0.1:${config.port}`)
-    app.cloud.whenAdminCreated(() => cb(err))
+    app.cloud.whenAdminCreated(() => cb(err, app))
   })
 
   app.isRemote = false

--- a/test/quotas.js
+++ b/test/quotas.js
@@ -146,3 +146,100 @@ test.cb('stop test server', t => {
     })
   })
 })
+
+test.cb('start test server', t => {
+  createTestServer(async (err, _app) => {
+    t.ifError(err)
+    app = _app
+
+    // login
+    var res = await app.req.post({
+      uri: '/v2/accounts/login',
+      json: {
+        'username': 'admin',
+        'password': 'foobar'
+      }
+    })
+    if (res.statusCode !== 200) throw new Error('Failed to login as admin')
+    sessionToken = res.body.sessionToken
+    auth = { bearer: sessionToken }
+
+    t.end()
+  })
+})
+
+test('register and login bob', async t => {
+  // register bob
+  var res = await app.req.post({
+    uri: '/v2/accounts/register',
+    json: {
+      email: 'bob@example.com',
+      username: 'bob',
+      password: 'foobar',
+      passwordConfirm: 'foobar'
+    }
+  })
+  if (res.statusCode !== 201) throw new Error('Failed to register bob user')
+
+  // check sent mail and extract the verification nonce
+  var lastMail = app.cloud.mailer.transport.sentMail.pop()
+  var emailVerificationNonce = /([0-9a-f]{64})/.exec(lastMail.data.text)[0]
+
+  // verify via GET
+  res = await app.req.get({
+    uri: '/v2/accounts/verify',
+    qs: {
+      username: 'bob',
+      nonce: emailVerificationNonce
+    },
+    json: true
+  })
+  if (res.statusCode !== 200) throw new Error('Failed to verify bob user')
+
+  // login bob
+  res = await app.req.post({
+    uri: '/v2/accounts/login',
+    json: {
+      'username': 'bob',
+      'password': 'foobar'
+    }
+  })
+  if (res.statusCode !== 200) throw new Error('Failed to login as bob')
+  sessionToken = res.body.sessionToken
+  authUser = { bearer: sessionToken }
+})
+
+test('enforce name archives limit', async t => {
+  var json = {key: '0'.repeat(64), name: 'a'}
+  var res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
+  t.is(res.statusCode, 200, '200 added dat')
+
+  json = {key: '1'.repeat(64), name: 'b'}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
+  t.is(res.statusCode, 200, '200 added dat')
+
+  json = {key: '2'.repeat(64), name: 'c'}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
+  t.is(res.statusCode, 200, '200 added dat')
+
+  json = {key: '3'.repeat(64), name: 'd'}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
+  t.is(res.statusCode, 422, '422 too many named dats')
+
+  json = {key: '3'.repeat(64)}
+  res = await app.req.post({uri: '/v2/archives/add', json, auth: authUser})
+  t.is(res.statusCode, 200, '200 added dat')
+
+  json = {name: 'd'}
+  res = await app.req.post({uri: '/v2/archives/item/' + ('3'.repeat(64)), json, auth: authUser})
+  t.is(res.statusCode, 422, '422 too many named dats')
+})
+
+test.cb('stop test server', t => {
+  app.close(() => {
+    testDat.close(() => {
+      t.pass('closed')
+      t.end()
+    })
+  })
+})

--- a/test/quotas.js
+++ b/test/quotas.js
@@ -8,8 +8,9 @@ var sessionToken, auth, authUser
 var testDat, testDatKey
 
 test.cb('start test server', t => {
-  app = createTestServer(async err => {
+  createTestServer(async (err, _app) => {
     t.ifError(err)
+    app = _app
 
     // login
     var res = await app.req.post({

--- a/test/users.js
+++ b/test/users.js
@@ -9,8 +9,9 @@ var app
 // - carla (invalid, never verifies email)
 
 test.cb('start test server', t => {
-  app = createTestServer(err => {
+  createTestServer((err, _app) => {
     t.ifError(err)
+    app = _app
     t.end()
   })
 })

--- a/test/users.js
+++ b/test/users.js
@@ -84,10 +84,10 @@ test('register and GET verify', async t => {
 })
 
 test('register validation', async t => {
-  async function expectPass (inputs) {
-    var res = await app.req.post({uri: '/v2/accounts/register', json: inputs})
-    t.is(res.statusCode, 201, '201 good input')
-  }
+  // async function expectPass (inputs) {
+  //   var res = await app.req.post({uri: '/v2/accounts/register', json: inputs})
+  //   t.is(res.statusCode, 201, '201 good input')
+  // }
   async function expectFail (inputs, badParam) {
     var res = await app.req.post({uri: '/v2/accounts/register', json: inputs})
     t.is(res.statusCode, 422, '422 bad input')
@@ -101,10 +101,8 @@ test('register validation', async t => {
   await expectFail({ email: 'bob@example.com', username: 'a', password: 'foobar', passwordConfirm: 'foobar' }, 'username') // username too short
   await expectFail({ email: 'bob@example.com', username: 'bob.boy', password: 'foobar', passwordConfirm: 'foobar' }, 'username') // username has invalid chars
   await expectFail({ email: 'asdf', username: 'bob', password: 'foobar', passwordConfirm: 'foobar' }, 'email') // invalid email
+  await expectFail({ email: 'bob+foo@example.com', username: 'bobobobo', password: 'foobar', passwordConfirm: 'foobar' }) // invalid email
   // await expectFail({ email: 'bob@example.com', username: 'bob', password: 'foobar', passwordConfirm: 'foobaz' }, 'passwordConfirm') // invalid passwordConfirm TODO
-
-  // now allowed:
-  await expectPass({ email: 'bob+foo@example.com', username: 'bobobobo', password: 'foobar', passwordConfirm: 'foobar' })
 })
 
 test('register usernames are case insensitive', async t => {


### PR DESCRIPTION
Historically, we've used a Dat domains system where each archive would be hosted at:

```
dat://${archiveName}-${userName}.foo.com
```

And the one exception was if `archiveName === userName`, we'd do:

```
dat://${userName}.foo.com
```

And TBH it kind of sucked. You end up with `dat://foo-pfrazee.hashbase.io` and you really just want `dat://foo.hashbase.io`. That postfix was ugly and made the URLs hard to remember.

So this PR changes the naming policy to:

```
dat://${archiveName}.foo.com
```

And this will mean that any user can claim any subdomain, except for the ones which have been explicitly reserved by the service operators.

Details on this change:

 - Any existing archive will be renamed to `${archiveName}-${userName}` so that this deployment will not change any existing URLs.
 - Every user is limited to 25 named archives, for now. That's to prevent mass squatting.
 - Plus signs are now disallowed in emails again, to prevent people from signing up multiple times (to circumvent the named archive limit).