### PR TITLE
fix visibility of copy to clipboard notification

### DIFF
--- a/assets/css/pages/archive.less
+++ b/assets/css/pages/archive.less
@@ -10,6 +10,7 @@ main.archive {
     margin: 1rem 0;
     padding-bottom: 2.5rem !important;
     position: relative;
+    overflow: visible;
   }
 
   #admin-remove-archive-form,


### PR DESCRIPTION
This PR just to fix a small overflow issue with the copy to clipboard notification:

current:
<img width="198" alt="screen shot 2018-07-16 at 8 48 21 pm" src="https://user-images.githubusercontent.com/5248271/42795517-a5cbda98-8939-11e8-99de-9136155d303b.png">

fixed:
<img width="229" alt="screen shot 2018-07-16 at 8 48 05 pm" src="https://user-images.githubusercontent.com/5248271/42795518-a846f596-8939-11e8-9075-0a4a16180ef7.png">

