### PR TITLE
Problem: Link for self-hosting software is wrong

### DIFF
--- a/assets/html/support.html
+++ b/assets/html/support.html
@@ -36,8 +36,7 @@
         Can I self host Hashbase?
       </h3>
       <p>
-        Yes. The software that powers Hashbase, <a href="https://github.com/datprotocol/hypercloud">
-        Hypercloud</a>, is open source and easy to deploy.
+        Yes. The <a href="https://github.com/beakerbrowser/hashbase">software that powers Hashbase</a> is open source and easy to deploy.
       </p>
       <p>
         You may also find


### PR DESCRIPTION
Solution: Point people to beakerbrowser/hashbase instead of datprotocol/hypercloud