### PR TITLE
Correcting Cache-Control

### DIFF
--- a/lib/apis/archive-files.js
+++ b/lib/apis/archive-files.js
@@ -203,7 +203,7 @@ module.exports = class ArchiveFilesAPI {
         headersSent = true
         var headers = {
           'Content-Type': mimeType,
-          'Cache-Control': 'public, max-age: 60',
+          'Cache-Control': 'public, max-age=60',
           ETag
         }
         res.writeHead(statusCode, 'OK', headers)


### PR DESCRIPTION
The `max-age` cache response directive was not getting set correctly, uses a `=`.

Spotted while looking at something else and noticing that requests that I was expecting to see a `304` on was getting a `200`, also the request was not including an `ETag`, even though the original response had included one.